### PR TITLE
added a mutex lock to resolve race condition in csi-powerflex driver

### DIFF
--- a/api.go
+++ b/api.go
@@ -155,9 +155,10 @@ func basicAuth(username, password string) string {
 	return base64.StdEncoding.EncodeToString([]byte(auth))
 }
 
-func (c *Client) getJSONWithRetry(
-	method, uri string,
-	body, resp interface{}) error {
+func (c *Client) getJSONWithRetry(method, uri string, body, resp interface{}) error {
+
+	mu.Lock()
+	defer mu.Unlock()
 
 	headers := make(map[string]string, 2)
 	headers[api.HeaderKeyAccept] = accHeader


### PR DESCRIPTION
Adding a mutex lock to resolve a race condition in the csi-powerflex driver. Tested by running unit tests on csi-powerflex driver and confirming that they pass and that the race conditions are gone.