### PR TITLE
New: Support more than 2 SDS IPs

### DIFF
--- a/inttests/sds_test.go
+++ b/inttests/sds_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/dell/goscaleio"
 	"github.com/stretchr/testify/assert"
+
+	types "github.com/dell/goscaleio/types/v1"
 )
 
 // getAllSds will return all SDS instances
@@ -116,6 +118,24 @@ func TestCreateSdsInvalid(t *testing.T) {
 	sdsName := "invalid"
 	sdsIPList := []string{"0.1.1.1", "0.2.2.2"}
 	sdsID, err := pd.CreateSds(sdsName, sdsIPList)
+	assert.NotNil(t, err)
+	assert.Equal(t, "", sdsID)
+
+}
+
+// TestCreateSdsInvalid will attempt to add an SDS, which results in failure
+func TestCreateSdsIPRoleInvalid(t *testing.T) {
+	pd := getProtectionDomain(t)
+	assert.NotNil(t, pd)
+
+	// attempt to create an SDS with a number of invalid IPs
+	// this is done, in a failure mode, to prevent changing the Protection Domain used for testing
+	sdsName := "invalid"
+	sdsIPList := []types.SdsIP{
+		{IP: "0.1.1.1", Role: goscaleio.RoleAll},
+		{IP: "0.2.2.2", Role: goscaleio.RoleSdcOnly},
+	}
+	sdsID, err := pd.CreateSdsWithIPRole(sdsName, sdsIPList)
 	assert.NotNil(t, err)
 	assert.Equal(t, "", sdsID)
 


### PR DESCRIPTION
# Description
Earlier, it was only possible to create an SDS with only two IPs and their roles were decided automatically.
I have added a function so that the user can create SDS with as many IPs as allowed by REST API and the user must explicitly specify the roles of each IP in this case. There is also validation built in so that wrong combination of IP roles can be detected.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

I tested this from an dummy script and verified that an SDS with 3 IPs can be created using the protectionDomain.CreateSdsWithIPRole function.

The script basically ran 
```go
sds, err4 := pd.CreateSdsWithIPRole("SDS_Test_Tf", []types.SdsIP{
		{IP: "10.247.100.231", Role: goscaleio.RoleAll},
		{IP: "10.247.77.82", Role: goscaleio.RoleSdcOnly},
		{IP: "10.247.77.83", Role: goscaleio.RoleSdcOnly},
	})
```
and on running it, I got
```
root@lglap049:~/test# go run main.go 
Found single system 0e7a082862fedf0f
Got system 0e7a082862fedf0f
Found pd 4eeb304600000000
Created sds 6ae199c500000007
root@lglap049:~/test# 
```
And the generated sds looks like 
```json
{
    "ipList": [
        {
            "ip": "10.247.100.231",
            "role": "all"
        },
        {
            "ip": "10.247.77.82",
            "role": "sdcOnly"
        },
        {
            "ip": "10.247.77.83",
            "role": "sdcOnly"
        }
    ],
    "onVmWare": true,
    "protectionDomainId": "4eeb304600000000",
    "perfProfile": "HighPerformance",
    "faultSetId": null,
    "softwareVersionInfo": "R3_6.0.0",
    "sdsState": "Normal",
    "membershipState": "Joined",
    "mdmConnectionState": "Connected",
    "drlMode": "Volatile",
    "configuredDrlMode": "Volatile",
    "rmcacheEnabled": true,
    "rmcacheSizeInKb": 131072,
    "rmcacheFrozen": false,
    "rmcacheMemoryAllocationState": "AllocationPending",
    "rfcacheEnabled": true,
    "maintenanceState": "NoMaintenance",
    "maintenanceType": "NoMaintenance",
    "sdsDecoupled": null,
    "sdsConfigurationFailure": null,
    "sdsReceiveBufferAllocationFailures": null,
    "rfcacheErrorLowResources": false,
    "rfcacheErrorApiVersionMismatch": false,
    "rfcacheErrorInconsistentCacheConfiguration": false,
    "rfcacheErrorInconsistentSourceConfiguration": false,
    "rfcacheErrorInvalidDriverPath": false,
    "certificateInfo": null,
    "authenticationError": "None",
    "raidControllers": null,
    "fglNumConcurrentWrites": 1000,
    "fglMetadataCacheState": "Disabled",
    "fglMetadataCacheSize": 0,
    "numRestarts": 1,
    "lastUpgradeTime": 0,
    "rfcacheErrorDeviceDoesNotExist": false,
    "numOfIoBuffers": null,
    "name": "SDS_Test_Tf",
    "port": 7072,
    "id": "6ae199c500000007",
    "links": [
        {
            "rel": "self",
            "href": "/api/instances/Sds::6ae199c500000007"
        },
        {
            "rel": "/api/Sds/relationship/Statistics",
            "href": "/api/instances/Sds::6ae199c500000007/relationships/Statistics"
        },
        {
            "rel": "/api/Sds/relationship/SpSds",
            "href": "/api/instances/Sds::6ae199c500000007/relationships/SpSds"
        },
        {
            "rel": "/api/Sds/relationship/Device",
            "href": "/api/instances/Sds::6ae199c500000007/relationships/Device"
        },
        {
            "rel": "/api/parent/relationship/protectionDomainId",
            "href": "/api/instances/ProtectionDomain::4eeb304600000000"
        }
    ]
}
```
