### PR TITLE
Fix: Send empty body for SDS deletion request

### DIFF
--- a/sds.go
+++ b/sds.go
@@ -178,7 +178,8 @@ func (pd *ProtectionDomain) DeleteSds(id string) error {
 
 	path := fmt.Sprintf("/api/instances/Sds::%v/action/removeSds", id)
 
-	err := pd.client.getJSONWithRetry(http.MethodPost, path, nil, nil)
+	sdsParam := &types.EmptyPayload{}
+	err := pd.client.getJSONWithRetry(http.MethodPost, path, sdsParam, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description
This fixes a minor bug, where a null body is sent on SDS deletion requests and that results in "Bad Request" error.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
I tested this from an independent script, where I created an SDS and deleted it.
The logs from the script
```
root@lglap049:~/test# go run main.go 
Found single system 0e7a082862fedf0f
Got system 0e7a082862fedf0f
Found pd 4eeb304600000000
Created sds with id 6ae2842400000008
Found sds with id 6ae2842400000008 and name Tf_SDS_02
The path for deletion is /api/instances/Sds::6ae2842400000008/action/removeSds
ID matches!
Deleted sds 6ae2842400000008
root@lglap049:~/test# 
```

