### PR TITLE
New: Enhanced SDS creation function and fixed SDS read

### DIFF
--- a/inttests/run-integration.sh
+++ b/inttests/run-integration.sh
@@ -51,5 +51,5 @@ fi
 
 # Run the integration tests
 echo "Starting tests"
-go test -v -coverprofile=c.out -coverpkg github.com/dell/goscaleio .
+go test -v -coverprofile=c.out -coverpkg github.com/dell/goscaleio . -run TestCreateSdsParams
 

--- a/inttests/run-integration.sh
+++ b/inttests/run-integration.sh
@@ -51,5 +51,5 @@ fi
 
 # Run the integration tests
 echo "Starting tests"
-go test -v -coverprofile=c.out -coverpkg github.com/dell/goscaleio . -run TestCreateSdsParams
+go test -v -coverprofile=c.out -coverpkg github.com/dell/goscaleio .
 

--- a/inttests/sds_test.go
+++ b/inttests/sds_test.go
@@ -124,18 +124,22 @@ func TestCreateSdsInvalid(t *testing.T) {
 }
 
 // TestCreateSdsInvalid will attempt to add an SDS, which results in failure
-func TestCreateSdsIPRoleInvalid(t *testing.T) {
+func TestCreateSdsParamsInvalid(t *testing.T) {
 	pd := getProtectionDomain(t)
 	assert.NotNil(t, pd)
 
 	// attempt to create an SDS with a number of invalid IPs
 	// this is done, in a failure mode, to prevent changing the Protection Domain used for testing
 	sdsName := "invalid"
-	sdsIPList := []types.SdsIP{
-		{IP: "0.1.1.1", Role: goscaleio.RoleAll},
-		{IP: "0.2.2.2", Role: goscaleio.RoleSdcOnly},
+	sdsIPList := []*types.SdsIPList{
+		{SdsIP: types.SdsIP{IP: "0.1.1.1", Role: goscaleio.RoleAll}},
+		{SdsIP: types.SdsIP{IP: "0.2.2.2", Role: goscaleio.RoleSdcOnly}},
 	}
-	sdsID, err := pd.CreateSdsWithIPRole(sdsName, sdsIPList)
+	sdsParam := &types.SdsParam{
+		Name:   sdsName,
+		IPList: sdsIPList,
+	}
+	sdsID, err := pd.CreateSdsWithParams(sdsParam)
 	assert.NotNil(t, err)
 	assert.Equal(t, "", sdsID)
 

--- a/inttests/sds_test.go
+++ b/inttests/sds_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/dell/goscaleio"
@@ -131,9 +132,9 @@ func TestCreateSdsParamsInvalid(t *testing.T) {
 	// attempt to create an SDS with a number of invalid IPs
 	// this is done, in a failure mode, to prevent changing the Protection Domain used for testing
 	sdsName := "invalid"
-	sdsIPList := []*types.SdsIPList{
-		{SdsIP: types.SdsIP{IP: "0.1.1.1", Role: goscaleio.RoleAll}},
-		{SdsIP: types.SdsIP{IP: "0.2.2.2", Role: goscaleio.RoleSdcOnly}},
+	sdsIPList := []*types.SdsIP{
+		{IP: "0.1.1.1", Role: goscaleio.RoleAll},
+		{IP: "0.2.2.2", Role: goscaleio.RoleSdcOnly},
 	}
 	sdsParam := &types.Sds{
 		Name:   sdsName,
@@ -151,10 +152,10 @@ func TestCreateSdsParams(t *testing.T) {
 
 	// attempt to create an SDS with a number of invalid IPs
 	// this is done, in a failure mode, to prevent changing the Protection Domain used for testing
-	sdsName := "Tf_SDS_01"
-	sdsIPList := []*types.SdsIPList{
-		{SdsIP: types.SdsIP{IP: "10.247.100.232", Role: goscaleio.RoleAll}},
-		{SdsIP: types.SdsIP{IP: "0.2.2.2", Role: goscaleio.RoleSdcOnly}},
+	sdsName := "Tf_SDS_rounak"
+	sdsIPList := []*types.SdsIP{
+		{IP: "10.247.100.232", Role: goscaleio.RoleAll},
+		{IP: "0.2.2.2", Role: goscaleio.RoleSdcOnly},
 	}
 	sdsParam := types.Sds{
 		Name:           sdsName,
@@ -179,7 +180,16 @@ func TestCreateSdsParams(t *testing.T) {
 	t.Logf("The port is %d", rsp.Port)
 	t.Logf("The rmcacheenabled is %v", rsp.RmcacheEnabled)
 	t.Logf("The rmcachesize in kb is %v", rsp.RmcacheSizeInKb)
+	t.Logf("The ip list is %v", strSds(rsp.IPList))
 
+}
+
+func strSds(ips []*types.SdsIP) string {
+	ret := ""
+	for _, ip := range ips {
+		ret += fmt.Sprintf("{IP: %s, role: %s},", ip.IP, ip.Role)
+	}
+	return ret
 }
 
 // TestDeleteSds will attempt to delete an SDS, which results in faliure

--- a/inttests/sds_test.go
+++ b/inttests/sds_test.go
@@ -146,44 +146,6 @@ func TestCreateSdsParamsInvalid(t *testing.T) {
 
 }
 
-func TestCreateSdsParams(t *testing.T) {
-	pd := getProtectionDomain(t)
-	assert.NotNil(t, pd)
-
-	// attempt to create an SDS with a number of invalid IPs
-	// this is done, in a failure mode, to prevent changing the Protection Domain used for testing
-	sdsName := "Tf_SDS_rounak"
-	sdsIPList := []*types.SdsIP{
-		{IP: "10.247.100.232", Role: goscaleio.RoleAll},
-		{IP: "0.2.2.2", Role: goscaleio.RoleSdcOnly},
-	}
-	sdsParam := types.Sds{
-		Name:           sdsName,
-		IPList:         sdsIPList,
-		DrlMode:        "NonVolatile",
-		RmcacheEnabled: true,
-		// this one is not working... god knows why
-		NumOfIoBuffers:  1,
-		RmcacheSizeInKb: 256000,
-	}
-	sdsID, err := pd.CreateSdsWithParams(&sdsParam)
-	assert.Nilf(t, err, "could not create sds with name %s", sdsName)
-	// assert.Equal(t, "", sdsID)
-
-	rsp, err3 := pd.FindSds("ID", sdsID)
-	assert.Nilf(t, err3, "could not find sds with id %s", sdsID)
-
-	assert.Equal(t, rsp.DrlMode, "NonVolatile")
-
-	// io buffers is always zero
-	t.Logf("The number of I/O buffers is %d", rsp.NumOfIoBuffers)
-	t.Logf("The port is %d", rsp.Port)
-	t.Logf("The rmcacheenabled is %v", rsp.RmcacheEnabled)
-	t.Logf("The rmcachesize in kb is %v", rsp.RmcacheSizeInKb)
-	t.Logf("The ip list is %v", strSds(rsp.IPList))
-
-}
-
 func strSds(ips []*types.SdsIP) string {
 	ret := ""
 	for _, ip := range ips {

--- a/sds.go
+++ b/sds.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strconv"
 	"time"
 
 	types "github.com/dell/goscaleio/types/v1"
@@ -81,11 +82,29 @@ func (pd *ProtectionDomain) CreateSds(
 	return pd.createSds(sdsParam)
 }
 
+func getNonZeroIntType(i int) string {
+	if i == 0 {
+		return ""
+	}
+	return strconv.Itoa(i)
+}
+
 // CreateSdsWithParams creates a new Sds with user defined SdsParam struct
-func (pd *ProtectionDomain) CreateSdsWithParams(sdsParam *types.SdsParam) (string, error) {
+func (pd *ProtectionDomain) CreateSdsWithParams(sds *types.Sds) (string, error) {
 	defer TimeSpent("CreateSdsWithParams", time.Now())
 
-	sdsParam.ProtectionDomainID = pd.ProtectionDomain.ID
+	sdsParam := &types.SdsParam{
+		Name:               sds.Name,
+		ProtectionDomainID: pd.ProtectionDomain.ID,
+		Port:               getNonZeroIntType(sds.Port),
+		RmcacheEnabled:     types.GetBoolType(sds.RmcacheEnabled),
+		RmcacheSizeInKb:    getNonZeroIntType(sds.RmcacheSizeInKb),
+		FaultSetID:         sds.FaultSetID,
+		NumOfIoBuffers:     getNonZeroIntType(sds.NumOfIoBuffers),
+		DrlMode:            sds.DrlMode,
+		IPList:             sds.IPList,
+	}
+
 	ipList := sdsParam.IPList
 
 	if len(ipList) == 0 {

--- a/sds.go
+++ b/sds.go
@@ -81,35 +81,28 @@ func (pd *ProtectionDomain) CreateSds(
 	return pd.createSds(sdsParam)
 }
 
-// CreateSdsWithIPRole creates a new Sds with user-assigned roles to IPs
-func (pd *ProtectionDomain) CreateSdsWithIPRole(
-	name string, ipList []types.SdsIP) (string, error) {
-	defer TimeSpent("CreateSdsWithIPRole", time.Now())
+// CreateSdsWithParams creates a new Sds with user defined SdsParam struct
+func (pd *ProtectionDomain) CreateSdsWithParams(sdsParam *types.SdsParam) (string, error) {
+	defer TimeSpent("CreateSdsWithParams", time.Now())
 
-	sdsParam := &types.SdsParam{
-		Name:               name,
-		ProtectionDomainID: pd.ProtectionDomain.ID,
-	}
+	sdsParam.ProtectionDomainID = pd.ProtectionDomain.ID
+	ipList := sdsParam.IPList
 
 	if len(ipList) == 0 {
 		return "", fmt.Errorf("Must provide at least 1 SDS IP")
 	} else if len(ipList) == 1 {
-		if ipList[0].Role != RoleAll {
+		if ipList[0].SdsIP.Role != RoleAll {
 			return "", fmt.Errorf("The only IP assigned to an SDS must be assigned \"%s\" role", RoleAll)
 		}
-		sdsIPList := &types.SdsIPList{SdsIP: ipList[0]}
-		sdsParam.IPList = append(sdsParam.IPList, sdsIPList)
 	} else if len(ipList) >= 2 {
 		nSdsOnly, nSdcOnly := 0, 0
 		for _, i := range ipList {
-			if i.Role == RoleAll || i.Role == RoleSdcOnly {
+			if i.SdsIP.Role == RoleAll || i.SdsIP.Role == RoleSdcOnly {
 				nSdcOnly++
 			}
-			if i.Role == RoleAll || i.Role == RoleSdsOnly {
+			if i.SdsIP.Role == RoleAll || i.SdsIP.Role == RoleSdsOnly {
 				nSdsOnly++
 			}
-			sdsIPList := &types.SdsIPList{SdsIP: i}
-			sdsParam.IPList = append(sdsParam.IPList, sdsIPList)
 		}
 		if nSdsOnly < 1 {
 			return "", fmt.Errorf("At least one IP must be assigned %s or %s role", RoleSdsOnly, RoleAll)

--- a/sds.go
+++ b/sds.go
@@ -100,9 +100,10 @@ func (pd *ProtectionDomain) CreateSdsWithParams(sds *types.Sds) (string, error) 
 		RmcacheEnabled:     types.GetBoolType(sds.RmcacheEnabled),
 		RmcacheSizeInKb:    getNonZeroIntType(sds.RmcacheSizeInKb),
 		FaultSetID:         sds.FaultSetID,
-		NumOfIoBuffers:     getNonZeroIntType(sds.NumOfIoBuffers),
-		DrlMode:            sds.DrlMode,
-		IPList:             make([]*types.SdsIPList, 0),
+		// TODO: NumOfIoBuffers is not working yet
+		NumOfIoBuffers: getNonZeroIntType(sds.NumOfIoBuffers),
+		DrlMode:        sds.DrlMode,
+		IPList:         make([]*types.SdsIPList, 0),
 	}
 
 	ipList := sds.IPList

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -356,22 +356,22 @@ type SdsIPList struct {
 
 // Sds defines struct for Sds
 type Sds struct {
-	ID                           string       `json:"id"`
-	Name                         string       `json:"name,omitempty"`
-	ProtectionDomainID           string       `json:"protectionDomainId"`
-	IPList                       []*SdsIPList `json:"ipList"`
-	Port                         int          `json:"port,omitempty"`
-	SdsState                     string       `json:"sdsState"`
-	MembershipState              string       `json:"membershipState"`
-	MdmConnectionState           string       `json:"mdmConnectionState"`
-	DrlMode                      string       `json:"drlMode,omitempty"`
-	RmcacheEnabled               bool         `json:"rmcacheEnabled,omitempty"`
-	RmcacheSizeInKb              int          `json:"rmcacheSizeInKb,omitempty"`
-	RmcacheFrozen                bool         `json:"rmcacheFrozen,omitempty"`
-	IsOnVMware                   bool         `json:"isOnVmWare,omitempty"`
-	FaultSetID                   string       `json:"faultSetId,omitempty"`
-	NumOfIoBuffers               int          `json:"numOfIoBuffers,omitempty"`
-	RmcacheMemoryAllocationState string       `json:"RmcacheMemoryAllocationState,omitempty"`
+	ID                           string   `json:"id"`
+	Name                         string   `json:"name,omitempty"`
+	ProtectionDomainID           string   `json:"protectionDomainId"`
+	IPList                       []*SdsIP `json:"ipList"`
+	Port                         int      `json:"port,omitempty"`
+	SdsState                     string   `json:"sdsState"`
+	MembershipState              string   `json:"membershipState"`
+	MdmConnectionState           string   `json:"mdmConnectionState"`
+	DrlMode                      string   `json:"drlMode,omitempty"`
+	RmcacheEnabled               bool     `json:"rmcacheEnabled,omitempty"`
+	RmcacheSizeInKb              int      `json:"rmcacheSizeInKb,omitempty"`
+	RmcacheFrozen                bool     `json:"rmcacheFrozen,omitempty"`
+	IsOnVMware                   bool     `json:"isOnVmWare,omitempty"`
+	FaultSetID                   string   `json:"faultSetId,omitempty"`
+	NumOfIoBuffers               int      `json:"numOfIoBuffers,omitempty"`
+	RmcacheMemoryAllocationState string   `json:"RmcacheMemoryAllocationState,omitempty"`
 }
 
 // DeviceInfo defines struct for DeviceInfo

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -19,6 +19,18 @@ import (
 )
 
 const errorWithDetails = "Error with details"
+const (
+	trueType  = "TRUE"
+	falseType = "FALSE"
+)
+
+// GetBoolType returns the true and false strings expected by the REST API
+func GetBoolType(b bool) string {
+	if b {
+		return trueType
+	}
+	return falseType
+}
 
 // ErrorMessageDetails defines contents of an error msg
 type ErrorMessageDetails struct {
@@ -373,14 +385,14 @@ type DeviceInfo struct {
 type SdsParam struct {
 	Name               string        `json:"name,omitempty"`
 	IPList             []*SdsIPList  `json:"sdsIpList"`
-	Port               int           `json:"sdsPort,omitempty"`
+	Port               string        `json:"sdsPort,omitempty"`
 	DrlMode            string        `json:"drlMode,omitempty"`
-	RmcacheEnabled     bool          `json:"rmcacheEnabled,omitempty"`
-	RmcacheSizeInKb    int           `json:"rmcacheSizeInKb,omitempty"`
+	RmcacheEnabled     string        `json:"rmcacheEnabled,omitempty"`
+	RmcacheSizeInKb    string        `json:"rmcacheSizeInKb,omitempty"`
 	RmcacheFrozen      bool          `json:"rmcacheFrozen,omitempty"`
 	ProtectionDomainID string        `json:"protectionDomainId"`
 	FaultSetID         string        `json:"faultSetId,omitempty"`
-	NumOfIoBuffers     int           `json:"numOfIoBuffers,omitempty"`
+	NumOfIoBuffers     string        `json:"numOfIoBuffers,omitempty"`
 	DeviceInfoList     []*DeviceInfo `json:"deviceInfoList,omitempty"`
 	ForceClean         bool          `json:"forceClean,omitempty"`
 	DeviceTestTimeSecs int           `json:"deviceTestTimeSecs ,omitempty"`


### PR DESCRIPTION
# Description
Enhanced SDS creation function: Earlier, SDS could only be created with user defined name and IP list. Now the user can set every field defined in types.Sds struct.
Fix for SDS read: The sds ip json returned on read is different from the sds ip json that need to be passed for create. Earlier, SDS IPs were not getting properly unmarshalled from json into types.Sds struct. Now it is.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

This has been tested using the https://github.com/dell/goscaleio/blob/sds-ip-read-test/inttests/sds_test.go#L149 test.
```
root@lglap049:~/goscaleio# make int-test
The SDC is not installed
All of the drv_cfg tests cannot be run
Starting tests
=== RUN   TestCreateSdsParamsInvalid
--- PASS: TestCreateSdsParamsInvalid (0.43s)
=== RUN   TestCreateSdsParams
    sds_test.go:179: The number of I/O buffers is 0
    sds_test.go:180: The port is 7072
    sds_test.go:181: The rmcacheenabled is true
    sds_test.go:182: The rmcachesize in kb is 256000
    sds_test.go:183: The ip list is {IP: 10.247.100.232, role: all},{IP: 0.2.2.2, role: sdcOnly},
--- PASS: TestCreateSdsParams (0.23s)
PASS
coverage: 18.0% of statements in github.com/dell/goscaleio
ok      github.com/dell/goscaleio/inttests      0.721s  coverage: 18.0% of statements in github.com/dell/goscaleio
root@lglap049:~/goscaleio#
```

After removal of test changes, unit tests has been run from this branch
```
root@lglap049:~/goscaleio# make int-test
The SDC is not installed
All of the drv_cfg tests cannot be run
Starting tests
=== RUN   TestGetDevices
--- PASS: TestGetDevices (0.14s)
=== RUN   TestGetDeviceByAttribute
--- PASS: TestGetDeviceByAttribute (0.31s)
=== RUN   TestGetDeviceByAttributeInvalid
--- PASS: TestGetDeviceByAttributeInvalid (0.32s)
=== RUN   TestAddDeviceInvalid
--- PASS: TestAddDeviceInvalid (0.15s)
=== RUN   TestGetDrvCfgGUID
    drv_cfg_test.go:39: PowerFlex SDC is not installed. Cannot validate DrvCfg functionality
--- SKIP: TestGetDrvCfgGUID (0.00s)
=== RUN   TestGetDrvCfgGUIDSDCNotInstalled
--- PASS: TestGetDrvCfgGUIDSDCNotInstalled (0.00s)
=== RUN   TestGetDrvCfgSystems
    drv_cfg_test.go:79: PowerFlex SDC is not installed. Cannot validate DrvCfg functionality
--- SKIP: TestGetDrvCfgSystems (0.00s)
=== RUN   TestGetDrvCfgSystemsSDCNotInstalled
--- PASS: TestGetDrvCfgSystemsSDCNotInstalled (0.00s)
=== RUN   TestGetDrvCfgQueryRescan
    drv_cfg_test.go:111: PowerFlex SDC is not installed. Cannot validate DrvCfg functionality
--- SKIP: TestGetDrvCfgQueryRescan (0.00s)
=== RUN   TestGetDrvCfgQueryRescanSDCNotInstalled
--- PASS: TestGetDrvCfgQueryRescanSDCNotInstalled (0.00s)
=== RUN   TestGetProtectionDomains
--- PASS: TestGetProtectionDomains (0.09s)
=== RUN   TestGetProtectionDomainByName
--- PASS: TestGetProtectionDomainByName (0.18s)
=== RUN   TestGetProtectionDomainByID
--- PASS: TestGetProtectionDomainByID (0.18s)
=== RUN   TestGetProtectionDomainByNameInvalid
--- PASS: TestGetProtectionDomainByNameInvalid (0.09s)
=== RUN   TestGetProtectionDomainByIDInvalid
--- PASS: TestGetProtectionDomainByIDInvalid (0.09s)
=== RUN   TestCreateDeleteProtectionDomain
--- PASS: TestCreateDeleteProtectionDomain (0.24s)
=== RUN   TestGetSdcs
--- PASS: TestGetSdcs (0.11s)
=== RUN   TestGetSdcByAttribute
--- PASS: TestGetSdcByAttribute (0.29s)
=== RUN   TestGetSdcByAttributeInvalid
--- PASS: TestGetSdcByAttributeInvalid (0.28s)
=== RUN   TestGetSdcStatistics
--- PASS: TestGetSdcStatistics (3.77s)
=== RUN   TestGetSdcVolumes
--- PASS: TestGetSdcVolumes (3.55s)
=== RUN   TestFindSdcVolumes
--- PASS: TestFindSdcVolumes (3.56s)
=== RUN   TestChangeSdcName
--- PASS: TestChangeSdcName (0.15s)
=== RUN   TestGetSDSs
--- PASS: TestGetSDSs (0.19s)
=== RUN   TestGetSDSByAttribute
--- PASS: TestGetSDSByAttribute (0.32s)
=== RUN   TestGetSDSByAttributeInvalid
--- PASS: TestGetSDSByAttributeInvalid (0.36s)
=== RUN   TestCreateSdsInvalid
--- PASS: TestCreateSdsInvalid (0.15s)
=== RUN   TestCreateSdsParamsInvalid
--- PASS: TestCreateSdsParamsInvalid (0.12s)
=== RUN   TestDeleteSds
--- PASS: TestDeleteSds (0.12s)
=== RUN   TestSetSDSIPRole
--- PASS: TestSetSDSIPRole (0.12s)
=== RUN   TestRemoveSDSIP
--- PASS: TestRemoveSDSIP (0.12s)
=== RUN   TestSetSdsName
--- PASS: TestSetSdsName (0.11s)
=== RUN   TestSetSdsPort
--- PASS: TestSetSdsPort (0.11s)
=== RUN   TestGetStoragePools
--- PASS: TestGetStoragePools (0.19s)
=== RUN   TestGetStoragePoolByName
--- PASS: TestGetStoragePoolByName (0.22s)
=== RUN   TestGetStoragePoolByID
--- PASS: TestGetStoragePoolByID (0.23s)
=== RUN   TestGetStoragePoolByNameInvalid
--- PASS: TestGetStoragePoolByNameInvalid (0.12s)
=== RUN   TestGetStoragePoolByIDInvalid
--- PASS: TestGetStoragePoolByIDInvalid (0.12s)
=== RUN   TestGetStoragePoolStatistics
--- PASS: TestGetStoragePoolStatistics (0.14s)
=== RUN   TestGetInstanceStoragePool
--- PASS: TestGetInstanceStoragePool (0.33s)
=== RUN   TestCreateDeleteStoragePool
--- PASS: TestCreateDeleteStoragePool (0.25s)
=== RUN   TestGetSDSStoragePool
--- PASS: TestGetSDSStoragePool (0.16s)
=== RUN   TestModifyStoragePoolName
--- PASS: TestModifyStoragePoolName (0.13s)
=== RUN   TestStoragePoolMediaType
    storagepool_test.go:250: 
                Error Trace:    storagepool_test.go:250
                Error:          Expected nil, but got: &goscaleio.Error{Message:"Could not find Storage Pool", HTTPStatusCode:500, ErrorCode:171, ErrorDetails:[]goscaleio.ErrorMessageDetails(nil)}
                Test:           TestStoragePoolMediaType
--- FAIL: TestStoragePoolMediaType (0.13s)
=== RUN   TestEnableRFCache
    storagepool_test.go:258: 
                Error Trace:    storagepool_test.go:258
                Error:          Expected nil, but got: &goscaleio.Error{Message:"Could not find Storage Pool", HTTPStatusCode:500, ErrorCode:171, ErrorDetails:[]goscaleio.ErrorMessageDetails(nil)}
                Test:           TestEnableRFCache
--- FAIL: TestEnableRFCache (0.12s)
=== RUN   TestDisableRFCache
    storagepool_test.go:266: 
                Error Trace:    storagepool_test.go:266
                Error:          Expected nil, but got: &goscaleio.Error{Message:"Could not find Storage Pool", HTTPStatusCode:500, ErrorCode:171, ErrorDetails:[]goscaleio.ErrorMessageDetails(nil)}
                Test:           TestDisableRFCache
--- FAIL: TestDisableRFCache (0.12s)
=== RUN   TestModifyRmCache
--- PASS: TestModifyRmCache (0.15s)
=== RUN   TestGetSystems
--- PASS: TestGetSystems (0.03s)
=== RUN   TestGetSingleSystemID
--- PASS: TestGetSingleSystemID (0.07s)
=== RUN   TestGetSingleSystemByIDInvalid
    system_test.go:58: 
                Error Trace:    system_test.go:58
                Error:          Expected value not to be nil.
                Test:           TestGetSingleSystemByIDInvalid
    system_test.go:59: 
                Error Trace:    system_test.go:59
                Error:          Expected nil, but got: &goscaleio.System{System:(*goscaleio.System)(0xc0001d2420), client:(*goscaleio.Client)(0xc0000c8000)}
                Test:           TestGetSingleSystemByIDInvalid
--- FAIL: TestGetSingleSystemByIDInvalid (0.03s)
=== RUN   TestGetSingleSystemByIDName
--- PASS: TestGetSingleSystemByIDName (0.03s)
=== RUN   TestGetSystemStatistics
--- PASS: TestGetSystemStatistics (0.09s)
=== RUN   TestGetAllUsers
--- PASS: TestGetAllUsers (0.09s)
=== RUN   TestGetVolumes
--- PASS: TestGetVolumes (0.66s)
=== RUN   TestFindVolumeID
[FindVolumeID] volumeID: 457cf8f900000139
--- PASS: TestFindVolumeID (0.21s)
=== RUN   TestCreateDeleteVolume
--- PASS: TestCreateDeleteVolume (0.21s)
=== RUN   TestCreateVolumeExistingName
--- PASS: TestCreateVolumeExistingName (0.37s)
=== RUN   TestDeleteNonExistentVolume
--- PASS: TestDeleteNonExistentVolume (0.24s)
=== RUN   TestCreateDeleteSnapshot
--- PASS: TestCreateDeleteSnapshot (0.39s)
=== RUN   TestGetVolumeVtree
--- PASS: TestGetVolumeVtree (0.27s)
=== RUN   TestGetVolumeStatistics
--- PASS: TestGetVolumeStatistics (0.26s)
=== RUN   TestResizeVolume
--- PASS: TestResizeVolume (0.27s)
=== RUN   TestMapQueryUnmapVolume
--- PASS: TestMapQueryUnmapVolume (0.41s)
=== RUN   TestMapQueryUnmapSnapshot
--- PASS: TestMapQueryUnmapSnapshot (0.78s)
=== RUN   TestCreateInstanceVolume
--- PASS: TestCreateInstanceVolume (0.12s)
=== RUN   TestCreateInstanceVolumeInvalidSize
--- PASS: TestCreateInstanceVolumeInvalidSize (0.06s)
=== RUN   TestGetInstanceVolume
[FindVolumeID] volumeID: 457cf90700000139
[FindVolumeID] volumeID: 
--- PASS: TestGetInstanceVolume (5.35s)
=== RUN   TestSetMappedSdcLimitsInvalid
--- PASS: TestSetMappedSdcLimitsInvalid (0.27s)
=== RUN   TestLockUnlockAutoSnapshot
--- PASS: TestLockUnlockAutoSnapshot (0.65s)
=== RUN   TestSetVolumeAccessModeLimit
--- PASS: TestSetVolumeAccessModeLimit (0.38s)
=== RUN   TestSetSnapshotSecurity
Will wait for 60 sec so that the retention period expires and snapshot can be deleted
--- PASS: TestSetSnapshotSecurity (60.62s)
=== RUN   TestSetVolumeMappingAccessMode
--- PASS: TestSetVolumeMappingAccessMode (0.68s)
FAIL
coverage: 70.3% of statements in github.com/dell/goscaleio
FAIL    github.com/dell/goscaleio/inttests      90.228s
FAIL
Makefile:11: recipe for target 'int-test' failed
make: *** [int-test] Error 1
root@lglap049:~/goscaleio# 
```
The errors seem unrelated to my changes as my changes are only sds related.

