### PR TITLE
Added the Support for Request Sdc Approval By Guid

### DIFF
--- a/sdc.go
+++ b/sdc.go
@@ -117,24 +117,28 @@ func (s *System) ApproveSdcByGUID(sdcGUID string) (*types.ApproveSdcByGUIDRespon
 	defer TimeSpent("ApproveSdcByGUID", time.Now())
 
 	var resp types.ApproveSdcByGUIDResponse
-	var err error
 
-	if s.System.RestrictedSdcModeEnabled && s.System.RestrictedSdcMode == "Guid" {
-		path := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", s.System.ID)
+	if s.System.RestrictedSdcModeEnabled {
+		if s.System.RestrictedSdcMode == "Guid" {
+			path := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", s.System.ID)
 
-		var body types.ApproveSdcParam = types.ApproveSdcParam{
-			SdcGUID: sdcGUID,
-		}
+			var body types.ApproveSdcParam = types.ApproveSdcParam{
+				SdcGUID: sdcGUID,
+			}
 
-		err := s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)
+			err := s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)
 
-		if err != nil {
-			return nil, err
+			if err != nil {
+				return nil, err
+			}
+
+			return &resp, nil
+
 		}
 
 	}
 
-	return &resp, err
+	return nil, nil
 
 }
 

--- a/sdc.go
+++ b/sdc.go
@@ -117,29 +117,20 @@ func (s *System) ApproveSdcByGUID(sdcGUID string) (*types.ApproveSdcByGUIDRespon
 	defer TimeSpent("ApproveSdcByGUID", time.Now())
 
 	var resp types.ApproveSdcByGUIDResponse
-	var err error
 
-	if s.System.RestrictedSdcModeEnabled {
-		if s.System.RestrictedSdcMode == "Guid" {
-			path := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", s.System.ID)
+	path := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", s.System.ID)
 
-			var body types.ApproveSdcParam = types.ApproveSdcParam{
-				SdcGUID: sdcGUID,
-			}
-
-			err = s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)
-
-			if err != nil {
-				return nil, err
-			}
-
-			return &resp, nil
-
-		}
-
+	var body types.ApproveSdcParam = types.ApproveSdcParam{
+		SdcGUID: sdcGUID,
 	}
 
-	return &resp, err
+	err := s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
 
 }
 

--- a/sdc.go
+++ b/sdc.go
@@ -112,6 +112,27 @@ func (s *System) FindSdc(field, value string) (*Sdc, error) {
 	return nil, errors.New("Couldn't find SDC")
 }
 
+func (s *System) ApproveSdcByGuid(sdcGuid string) (*types.ApproveSdcByGuidResponse, error) {
+	defer TimeSpent("ApproveSdcByGuid", time.Now())
+
+	path := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", s.System.ID)
+
+	var body types.ApproveSdcParam = types.ApproveSdcParam{
+		SdcGuid: sdcGuid,
+	}
+
+	var resp types.ApproveSdcByGuidResponse
+
+	err := s.client.getJSONWithRetry(http.MethodPost, path, body, resp)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, err
+
+}
+
 // GetStatistics returns a Sdc statistcs
 func (sdc *Sdc) GetStatistics() (*types.SdcStatistics, error) {
 	defer TimeSpent("GetStatistics", time.Now())

--- a/sdc.go
+++ b/sdc.go
@@ -112,7 +112,7 @@ func (s *System) FindSdc(field, value string) (*Sdc, error) {
 	return nil, errors.New("Couldn't find SDC")
 }
 
-// ApproveSdcByGuid approves the Sdc When the Powerflex Array is operating in Guid RestrictedSdcMode.
+// ApproveSdcByGUID approves the Sdc When the Powerflex Array is operating in Guid RestrictedSdcMode.
 func (s *System) ApproveSdcByGUID(sdcGUID string) (*types.ApproveSdcByGUIDResponse, error) {
 	defer TimeSpent("ApproveSdcByGUID", time.Now())
 

--- a/sdc.go
+++ b/sdc.go
@@ -117,6 +117,7 @@ func (s *System) ApproveSdcByGUID(sdcGUID string) (*types.ApproveSdcByGUIDRespon
 	defer TimeSpent("ApproveSdcByGUID", time.Now())
 
 	var resp types.ApproveSdcByGUIDResponse
+	var err error
 
 	if s.System.RestrictedSdcModeEnabled {
 		if s.System.RestrictedSdcMode == "Guid" {
@@ -126,7 +127,7 @@ func (s *System) ApproveSdcByGUID(sdcGUID string) (*types.ApproveSdcByGUIDRespon
 				SdcGUID: sdcGUID,
 			}
 
-			err := s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)
+			err = s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)
 
 			if err != nil {
 				return nil, err
@@ -138,7 +139,7 @@ func (s *System) ApproveSdcByGUID(sdcGUID string) (*types.ApproveSdcByGUIDRespon
 
 	}
 
-	return nil, nil
+	return &resp, err
 
 }
 

--- a/sdc.go
+++ b/sdc.go
@@ -112,17 +112,18 @@ func (s *System) FindSdc(field, value string) (*Sdc, error) {
 	return nil, errors.New("Couldn't find SDC")
 }
 
-func (s *System) ApproveSdcByGuid(sdcGuid string) (*types.ApproveSdcByGuidResponse, error) {
-	defer TimeSpent("ApproveSdcByGuid", time.Now())
+// ApproveSdcByGuid approves the Sdc When the Powerflex Array is operating in Guid RestrictedSdcMode.
+func (s *System) ApproveSdcByGUID(sdcGUID string) (*types.ApproveSdcByGUIDResponse, error) {
+	defer TimeSpent("ApproveSdcByGUID", time.Now())
 
-	var resp types.ApproveSdcByGuidResponse
+	var resp types.ApproveSdcByGUIDResponse
 	var err error
 
 	if s.System.RestrictedSdcModeEnabled && s.System.RestrictedSdcMode == "Guid" {
 		path := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", s.System.ID)
 
 		var body types.ApproveSdcParam = types.ApproveSdcParam{
-			SdcGuid: sdcGuid,
+			SdcGUID: sdcGUID,
 		}
 
 		err := s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)

--- a/sdc.go
+++ b/sdc.go
@@ -125,7 +125,7 @@ func (s *System) ApproveSdcByGuid(sdcGuid string) (*types.ApproveSdcByGuidRespon
 			SdcGuid: sdcGuid,
 		}
 
-		err := s.client.getJSONWithRetry(http.MethodPost, path, body, resp)
+		err := s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)
 
 		if err != nil {
 			return nil, err

--- a/sdc.go
+++ b/sdc.go
@@ -115,18 +115,22 @@ func (s *System) FindSdc(field, value string) (*Sdc, error) {
 func (s *System) ApproveSdcByGuid(sdcGuid string) (*types.ApproveSdcByGuidResponse, error) {
 	defer TimeSpent("ApproveSdcByGuid", time.Now())
 
-	path := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", s.System.ID)
-
-	var body types.ApproveSdcParam = types.ApproveSdcParam{
-		SdcGuid: sdcGuid,
-	}
-
 	var resp types.ApproveSdcByGuidResponse
+	var err error
 
-	err := s.client.getJSONWithRetry(http.MethodPost, path, body, resp)
+	if s.System.RestrictedSdcModeEnabled && s.System.RestrictedSdcMode == "Guid" {
+		path := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", s.System.ID)
 
-	if err != nil {
-		return nil, err
+		var body types.ApproveSdcParam = types.ApproveSdcParam{
+			SdcGuid: sdcGuid,
+		}
+
+		err := s.client.getJSONWithRetry(http.MethodPost, path, body, resp)
+
+		if err != nil {
+			return nil, err
+		}
+
 	}
 
 	return &resp, err

--- a/sdc_test.go
+++ b/sdc_test.go
@@ -178,33 +178,33 @@ func TestRenameSdc(t *testing.T) {
 }
 
 func TestApproveSdc(t *testing.T) {
-	type checkFn func(*testing.T, *types.ApproveSdcByGuidResponse, error)
+	type checkFn func(*testing.T, *types.ApproveSdcByGUIDResponse, error)
 	check := func(fns ...checkFn) []checkFn { return fns }
 
-	hasNoError := func(t *testing.T, resp *types.ApproveSdcByGuidResponse, err error) {
+	hasNoError := func(t *testing.T, resp *types.ApproveSdcByGUIDResponse, err error) {
 		if err != nil {
 			t.Fatalf("expected no error")
 		}
 	}
 
-	hasError := func(t *testing.T, resp *types.ApproveSdcByGuidResponse, err error) {
+	hasError := func(t *testing.T, resp *types.ApproveSdcByGUIDResponse, err error) {
 		if err == nil {
 			t.Fatalf("expected error")
 		}
 	}
 
-	checkResp := func(sdcId string) func(t *testing.T, resp *types.ApproveSdcByGuidResponse, err error) {
-		return func(t *testing.T, resp *types.ApproveSdcByGuidResponse, err error) {
-			assert.Equal(t, sdcId, resp.SdcId)
+	checkResp := func(sdcId string) func(t *testing.T, resp *types.ApproveSdcByGUIDResponse, err error) {
+		return func(t *testing.T, resp *types.ApproveSdcByGUIDResponse, err error) {
+			assert.Equal(t, sdcId, resp.SdcID)
 		}
 	}
 
 	tests := map[string]func(t *testing.T) (*httptest.Server, *types.System, []checkFn){
 		"success": func(t *testing.T) (*httptest.Server, *types.System, []checkFn) {
-			systemId := "0000aaabbbccc1111"
-			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemId)
+			systemID := "0000aaabbbccc1111"
+			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemID)
 			system := types.System{
-				ID:                       systemId,
+				ID:                       systemID,
 				RestrictedSdcModeEnabled: true,
 				RestrictedSdcMode:        "Guid",
 			}
@@ -218,8 +218,8 @@ func TestApproveSdc(t *testing.T) {
 					t.Fatal(fmt.Errorf("wrong path. Expected %s; but got %s", href, r.URL.Path))
 				}
 
-				resp := types.ApproveSdcByGuidResponse{
-					SdcId: "aab12340000000x",
+				resp := types.ApproveSdcByGUIDResponse{
+					SdcID: "aab12340000000x",
 				}
 
 				respData, err := json.Marshal(resp)
@@ -231,10 +231,10 @@ func TestApproveSdc(t *testing.T) {
 			return ts, &system, check(hasNoError, checkResp("aab12340000000x"))
 		},
 		"Already Approved err": func(t *testing.T) (*httptest.Server, *types.System, []checkFn) {
-			systemId := "0000aaabbbccc1111"
-			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemId)
+			systemID := "0000aaabbbccc1111"
+			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemID)
 			system := types.System{
-				ID:                       systemId,
+				ID:                       systemID,
 				RestrictedSdcModeEnabled: true,
 				RestrictedSdcMode:        "Guid",
 			}
@@ -255,10 +255,10 @@ func TestApproveSdc(t *testing.T) {
 
 		},
 		"Invalid guid err": func(t *testing.T) (*httptest.Server, *types.System, []checkFn) {
-			systemId := "0000aaabbbccc1111"
-			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemId)
+			systemID := "0000aaabbbccc1111"
+			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemID)
 			system := types.System{
-				ID:                       systemId,
+				ID:                       systemID,
 				RestrictedSdcModeEnabled: true,
 				RestrictedSdcMode:        "Guid",
 			}
@@ -301,7 +301,7 @@ func TestApproveSdc(t *testing.T) {
 				System: system,
 			}
 
-			resp, err := s.ApproveSdcByGuid(testCaseGuids[name])
+			resp, err := s.ApproveSdcByGUID(testCaseGuids[name])
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}

--- a/sdc_test.go
+++ b/sdc_test.go
@@ -176,3 +176,137 @@ func TestRenameSdc(t *testing.T) {
 	}
 
 }
+
+func TestApproveSdc(t *testing.T) {
+	type checkFn func(*testing.T, *types.ApproveSdcByGuidResponse, error)
+	check := func(fns ...checkFn) []checkFn { return fns }
+
+	hasNoError := func(t *testing.T, resp *types.ApproveSdcByGuidResponse, err error) {
+		if err != nil {
+			t.Fatalf("expected no error")
+		}
+	}
+
+	hasError := func(t *testing.T, resp *types.ApproveSdcByGuidResponse, err error) {
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+	}
+
+	checkResp := func(sdcId string) func(t *testing.T, resp *types.ApproveSdcByGuidResponse, err error) {
+		return func(t *testing.T, resp *types.ApproveSdcByGuidResponse, err error) {
+			assert.Equal(t, sdcId, resp.SdcId)
+		}
+	}
+
+	tests := map[string]func(t *testing.T) (*httptest.Server, *types.System, []checkFn){
+		"success": func(t *testing.T) (*httptest.Server, *types.System, []checkFn) {
+			systemId := "0000aaabbbccc1111"
+			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemId)
+			system := types.System{
+				ID:                       systemId,
+				RestrictedSdcModeEnabled: true,
+				RestrictedSdcMode:        "Guid",
+			}
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Fatal(fmt.Errorf("wrong method. Expected %s; but got %s", http.MethodPost, r.Method))
+				}
+
+				if r.URL.Path != href {
+					t.Fatal(fmt.Errorf("wrong path. Expected %s; but got %s", href, r.URL.Path))
+				}
+
+				resp := types.ApproveSdcByGuidResponse{
+					SdcId: "aab12340000000x",
+				}
+
+				respData, err := json.Marshal(resp)
+				if err != nil {
+					t.Fatal(err)
+				}
+				fmt.Fprintln(w, string(respData))
+			}))
+			return ts, &system, check(hasNoError, checkResp("aab12340000000x"))
+		},
+		"Already Approved err": func(t *testing.T) (*httptest.Server, *types.System, []checkFn) {
+			systemId := "0000aaabbbccc1111"
+			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemId)
+			system := types.System{
+				ID:                       systemId,
+				RestrictedSdcModeEnabled: true,
+				RestrictedSdcMode:        "Guid",
+			}
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Fatal(fmt.Errorf("wrong method. Expected %s; but got %s", http.MethodPost, r.Method))
+				}
+
+				if r.URL.Path != href {
+					t.Fatal(fmt.Errorf("wrong path. Expected %s; but got %s", href, r.URL.Path))
+				}
+
+				http.Error(w, "The SDC is already approved.", http.StatusInternalServerError)
+
+			}))
+			return ts, &system, check(hasError)
+
+		},
+		"Invalid guid err": func(t *testing.T) (*httptest.Server, *types.System, []checkFn) {
+			systemId := "0000aaabbbccc1111"
+			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemId)
+			system := types.System{
+				ID:                       systemId,
+				RestrictedSdcModeEnabled: true,
+				RestrictedSdcMode:        "Guid",
+			}
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Fatal(fmt.Errorf("wrong method. Expected %s; but got %s", http.MethodPost, r.Method))
+				}
+
+				if r.URL.Path != href {
+					t.Fatal(fmt.Errorf("wrong path. Expected %s; but got %s", href, r.URL.Path))
+				}
+
+				http.Error(w, "The given GUID is invalid. Please specify GUID in the following format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", http.StatusInternalServerError)
+
+			}))
+			return ts, &system, check(hasError)
+
+		},
+	}
+
+	var testCaseGuids = map[string]string{
+		"success":              "1aaabd94-9acd-11ed-a8fc-0242ac120002",
+		"Already Approved err": "1aaabd94-9acd-11ed-a8fc-0242ac120002",
+		"Invalid guid err":     "invald_guid",
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ts, system, checkFns := tc(t)
+			defer ts.Close()
+
+			client, err := NewClientWithArgs(ts.URL, "", true, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s := System{
+				client: client,
+				System: system,
+			}
+
+			resp, err := s.ApproveSdcByGuid(testCaseGuids[name])
+			for _, checkFn := range checkFns {
+				checkFn(t, resp, err)
+			}
+
+		})
+	}
+
+}

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -325,6 +325,14 @@ type ChangeSdcNameParam struct {
 	SdcName string `json:"sdcName"`
 }
 
+type ApproveSdcParam struct {
+	SdcGuid string `json:"sdcGuid"`
+}
+
+type ApproveSdcByGuidResponse struct {
+	SdcId string `json:"id"`
+}
+
 // ProtectionDomainResp defines struct for ProtectionDomainResp
 type ProtectionDomainResp struct {
 	ID string `json:"id"`

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -326,12 +326,14 @@ type ChangeSdcNameParam struct {
 	SdcName string `json:"sdcName"`
 }
 
+// ApproveSdcParam defines struct for ApproveSdcParam
 type ApproveSdcParam struct {
-	SdcGuid string `json:"sdcGuid"`
+	SdcGUID string `json:"sdcGuid"`
 }
 
-type ApproveSdcByGuidResponse struct {
-	SdcId string `json:"id"`
+// ApproveSdcByGUIDResponse defines struct for ApproveSdcByGUIDResponse
+type ApproveSdcByGUIDResponse struct {
+	SdcID string `json:"id"`
 }
 
 // ProtectionDomainResp defines struct for ProtectionDomainResp

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -90,6 +90,7 @@ type System struct {
 	MdmManagementIPList                   []string `json:"mdmManagementIPList"`
 	DefaultIsVolumeObfuscated             bool     `json:"defaultIsVolumeObfuscated"`
 	RestrictedSdcModeEnabled              bool     `json:"restrictedSdcModeEnabled"`
+	RestrictedSdcMode                     string   `json:"restrictedSdcMode"`
 	Swid                                  string   `json:"swid"`
 	DaysInstalled                         int      `json:"daysInstalled"`
 	MaxCapacityInGb                       string   `json:"maxCapacityInGb"`


### PR DESCRIPTION
# Description
This pr adds support for Sdc Approval By Guid when the Powerflex Array is operating in restricted Sdc mode.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/402 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Invoked ApproveSdc fn call on disapproved sdc by setting the Array in Restricted Mode
- [x] Invoked ApproveSdc fn call on Already Approved Sdc and Verified the Error messages.
- [x] Invoked ApproveSdc fn call by providing Invalid Guid and Verified the Corresponding Error messages.
- [x] Unit-tests
   `
   [root@master-1-xp5ldNW2QAGIH goscaleio]# go test -v -timeout 30s -run ^TestApproveSdc$ github.com/dell/goscaleio
=== RUN   TestApproveSdc
=== RUN   TestApproveSdc/success
=== RUN   TestApproveSdc/Already_Approved_err
=== RUN   TestApproveSdc/Invalid_guid_err
--- PASS: TestApproveSdc (0.00s)
    --- PASS: TestApproveSdc/success (0.00s)
    --- PASS: TestApproveSdc/Already_Approved_err (0.00s)
    --- PASS: TestApproveSdc/Invalid_guid_err (0.00s)
PASS
ok      github.com/dell/goscaleio       0.007s

   ` 

