### PR TITLE
Add support for replication on a PowerFlex 4.0 array

### DIFF
--- a/api.go
+++ b/api.go
@@ -79,7 +79,12 @@ func (c *Client) getVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			doLog(log.WithError(err).Error, "")
+		}
+	}()
 
 	// parse the response
 	switch {
@@ -143,7 +148,12 @@ func (c *Client) Authenticate(configConnect *ConfigConnect) (Cluster, error) {
 		doLog(log.WithError(err).Error, "")
 		return Cluster{}, err
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			doLog(log.WithError(err).Error, "")
+		}
+	}()
 
 	// parse the response
 	switch {
@@ -238,7 +248,11 @@ func (c *Client) getStringWithRetry(
 	addMetaData(headers, body)
 
 	checkResponse := func(resp *http.Response) (string, bool, error) {
-		defer resp.Body.Close()
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				doLog(log.WithError(err).Error, "")
+			}
+		}()
 
 		// parse the response
 		switch {

--- a/api/api.go
+++ b/api/api.go
@@ -255,7 +255,12 @@ func (c *client) DoWithHeaders(
 	if err != nil {
 		return err
 	}
-	defer res.Body.Close()
+
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			c.doLog(log.WithError(err).Error, "")
+		}
+	}()
 
 	// parse the response
 	switch {
@@ -319,7 +324,13 @@ func (c *client) DoAndGetResponseBody(
 	// marshal the message body (assumes json format)
 	if r, ok := body.(io.ReadCloser); ok {
 		req, err = http.NewRequest(method, u.String(), r)
-		defer r.Close()
+
+		defer func() {
+			if err := r.Close(); err != nil {
+				c.doLog(log.WithError(err).Error, "")
+			}
+		}()
+
 		if v, ok := headers[HeaderKeyContentType]; ok {
 			req.Header.Set(HeaderKeyContentType, v)
 		} else {

--- a/inttests/init_client.go
+++ b/inttests/init_client.go
@@ -67,7 +67,7 @@ func initClient2() bool {
 	}
 
 	C2, err = goscaleio.NewClientWithArgs(
-		os.Getenv(replicationEnpoint),
+		endpoint2,
 		os.Getenv("GOSCALEIO_VERSION"),
 		math.MaxInt64,
 		os.Getenv("GOSCALEIO_INSECURE") == "true",

--- a/inttests/replication_test.go
+++ b/inttests/replication_test.go
@@ -75,6 +75,7 @@ func TestGetPeerMDMs(t *testing.T) {
 
 	var targetSystemID string
 	for i := 0; i < len(tgtpeers); i++ {
+		fmt.Printf("Peer %d, %+v", i, tgtpeers[i])
 		targetSystemID = tgtpeers[i].SystemID
 	}
 
@@ -131,6 +132,7 @@ func TestGetTargetSystem(t *testing.T) {
 	}
 
 	rep.targetSystem = getTargetSystem()
+	fmt.Printf("Target: %+v", rep.targetSystem.System)
 	assert.NotNil(t, rep.targetSystem)
 }
 
@@ -362,6 +364,7 @@ func TestCreateReplicationConsistencyGroupSnapshot(t *testing.T) {
 	resp, err := rep.rcg.CreateReplicationConsistencyGroupSnapshot(false)
 	assert.Nil(t, err)
 
+	t.Logf("Consistency Group Snapshot ID: %s", resp.SnapshotGroupID)
 	rep.snapshotGroupID = resp.SnapshotGroupID
 }
 
@@ -456,7 +459,7 @@ func TestExecutePauseOnReplicationGroup(t *testing.T) {
 	err := waitForConsistency(t)
 	assert.Nil(t, err)
 
-	err = rep.rcg.ExecutePauseOnReplicationGroup(siotypes.OnlyTrackChanges)
+	err = rep.rcg.ExecutePauseOnReplicationGroup()
 	assert.Nil(t, err)
 }
 
@@ -622,6 +625,7 @@ func ensureFailover(t *testing.T) error {
 
 		if group.FailoverType != "None" && group.FailoverState == "Done" && group.DisasterRecoveryState == "Neutral" && group.RemoteDisasterRecoveryState == "Neutral" {
 			t.Logf("Consistency Group is in %s", group.FailoverType)
+			time.Sleep(1 * time.Second)
 			return nil
 		}
 

--- a/replication.go
+++ b/replication.go
@@ -229,11 +229,9 @@ func (rcg *ReplicationConsistencyGroup) CreateReplicationConsistencyGroupSnapsho
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/createReplicationConsistencyGroupSnapshots"
 	param := &types.CreateReplicationConsistencyGroupSnapshot{
-		Force: "false",
+		Force: force,
 	}
-	if force {
-		param.Force = "true"
-	}
+
 	resp := &types.CreateReplicationConsistencyGroupSnapshotResp{}
 
 	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, resp)
@@ -286,12 +284,12 @@ func (rcg *ReplicationConsistencyGroup) ExecuteReverseOnReplicationGroup() error
 }
 
 // ExecutePauseOnReplicationGroup pauses the replication of the ConsistencyGroup.
-func (rcg *ReplicationConsistencyGroup) ExecutePauseOnReplicationGroup(mode types.PauseMode) error {
+func (rcg *ReplicationConsistencyGroup) ExecutePauseOnReplicationGroup() error {
 	defer TimeSpent("ExecutePauseOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/pauseReplicationConsistencyGroup"
 	param := types.PauseReplicationConsistencyGroup{
-		PauseMode: string(mode),
+		PauseMode: string(types.StopDataTransfer),
 	}
 
 	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -824,16 +824,17 @@ type SnapshotPolicyQueryIDByKeyParam struct {
 
 // PeerMDM defines a replication peer system.
 type PeerMDM struct {
-	ID                  string `json:"id"`
-	Name                string `json:"name"`
-	Port                int    `json:"port"`
-	PeerSystemID        string `json:"peerSystemId"`
-	SystemID            string `json:"systemId"`
-	SoftwareVersionInfo string `json:"softwareVersionInfo"`
-	MembershipState     string `json:"membershipState"`
-	PerfProfile         string `json:"perfProfile"`
-	NetworkType         string `json:"networkType"`
-	CouplingRC          string `json:"couplingRC"`
+	ID                  string     `json:"id"`
+	Name                string     `json:"name"`
+	Port                int        `json:"port"`
+	PeerSystemID        string     `json:"peerSystemId"`
+	SystemID            string     `json:"systemId"`
+	SoftwareVersionInfo string     `json:"softwareVersionInfo"`
+	MembershipState     string     `json:"membershipState"`
+	PerfProfile         string     `json:"perfProfile"`
+	NetworkType         string     `json:"networkType"`
+	CouplingRC          string     `json:"couplingRC"`
+	IPList              []*PeerMDM `json:"ipList"`
 }
 
 // ReplicationConsistencyGroup (RCG) has information about a replication session
@@ -920,7 +921,7 @@ type RemoveReplicationPair struct {
 
 // CreateReplicationConsistencyGroupSnapshot defines struct for CreateReplicationConsistencyGroupSnapshot.
 type CreateReplicationConsistencyGroupSnapshot struct {
-	Force string `json:"force,omitempty"`
+	Force bool `json:"force,omitempty"`
 }
 
 // CreateReplicationConsistencyGroupSnapshotResp defines struct for CreateReplicationConsistencyGroupSnapshotResp.


### PR DESCRIPTION
# Description
Add support for all replication API calls in a PowerFlex 4.0 array. The main chances are:
- Changing the `force` flag in `CreateReplicationConsistencyGroupSnapshot` to a boolean.
- Changing the `PauseMode` to `StopDataTransfer` since that is only supported in a 4.0 system.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/618 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested to ensure that all of the replication integration tests work on both a PowerFlex 3.6 and PowerFlex 4.0 array.

