### PR TITLE
Add more functions to a protection domain

### DIFF
--- a/inttests/protectiondomain_test.go
+++ b/inttests/protectiondomain_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/dell/goscaleio"
+	types "github.com/dell/goscaleio/types/v1"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -164,4 +165,114 @@ func TestCreateDeleteProtectionDomain(t *testing.T) {
 	err = system.DeleteProtectionDomain(domainName)
 	assert.NotNil(t, err)
 
+}
+
+func TestCRUDProtectionDomain(t *testing.T) {
+	system := getSystem()
+	assert.NotNil(t, system)
+
+	domainName := fmt.Sprintf("%s-%s", testPrefix, "Domain")
+
+	// create the pd
+	domainID, err := system.CreateProtectionDomain(domainName)
+	assert.Nil(t, err)
+	assert.NotNil(t, domainID)
+
+	pd, err2 := system.GetProtectionDomainEx(domainID)
+	assert.Nil(t, err2)
+
+	// change name of pd
+	newName := fmt.Sprintf("%s2-%s", testPrefix, "Domain")
+	err = pd.SetName(newName)
+	assert.Nil(t, err)
+
+	// inactivate pd
+	err = pd.InActivate(false)
+	assert.Nil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, pd.ProtectionDomain.Name, newName)
+	assert.Equal(t, pd.ProtectionDomain.ProtectionDomainState, "Inactive")
+
+	testRfCacheProtectionDomain(t, pd)
+
+	testNwLimitsProtectionDomain(t, pd)
+
+	// activate pd
+	err = pd.Activate(true)
+	assert.Nil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, pd.ProtectionDomain.ProtectionDomainState, "Active")
+
+	// check that finding pd by name yields same struct as refreshing
+	pdByName, err3 := system.FindProtectionDomainByName(newName)
+	assert.Nil(t, err3)
+	assert.Equal(t, pd.ProtectionDomain, pdByName)
+
+	// delete pd
+	err = pd.Delete()
+	assert.Nil(t, err)
+}
+
+func testRfCacheProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
+	err := pd.DisableRfcache()
+	assert.Nil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+
+	p := types.PDRCModeRead
+	err = pd.SetRfcacheParams(types.PDRfCacheParams{p, 16, 64})
+	assert.Nil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheEnabled, false)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheOperationalMode, p)
+	assert.Equal(t, pd.ProtectionDomain.RfCachePageSizeKb, 16)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheMaxIoSizeKb, 64)
+
+	err = pd.EnableRfcache()
+	assert.Nil(t, err)
+	err = pd.SetRfcacheParams(types.PDRfCacheParams{"", 4, 0})
+	assert.Nil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheEnabled, true)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheOperationalMode, p)
+	assert.Equal(t, pd.ProtectionDomain.RfCachePageSizeKb, 4)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheMaxIoSizeKb, 64)
+
+	err = pd.SetRfcacheParams(types.PDRfCacheParams{"", 16, 32})
+	assert.Nil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheEnabled, true)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheOperationalMode, p)
+	assert.Equal(t, pd.ProtectionDomain.RfCachePageSizeKb, 16)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheMaxIoSizeKb, 32)
+}
+
+func testNwLimitsProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
+	old_pd := *pd.ProtectionDomain
+	a, b, c := 10*1024, 16*1024, 0
+	err := pd.SetSdsNetworkLimits(types.SdsNetworkLimitParams{nil, nil, &a, &b, &c})
+	assert.Nil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, pd.ProtectionDomain.RebuildNetworkThrottlingInKbps, old_pd.RebuildNetworkThrottlingInKbps)
+	assert.Equal(t, pd.ProtectionDomain.RebalanceNetworkThrottlingInKbps, old_pd.RebalanceNetworkThrottlingInKbps)
+	assert.Equal(t, pd.ProtectionDomain.VTreeMigrationNetworkThrottlingInKbps, a)
+	assert.Equal(t, pd.ProtectionDomain.ProtectedMaintenanceModeNetworkThrottlingInKbps, b)
+	assert.Equal(t, pd.ProtectionDomain.OverallIoNetworkThrottlingInKbps, c)
+
+	a1, c1 := 64*1024, 100*1024
+	err = pd.SetSdsNetworkLimits(types.SdsNetworkLimitParams{&a1, &a1, &a1, nil, &c1})
+	assert.Nil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, pd.ProtectionDomain.RebuildNetworkThrottlingInKbps, a1)
+	assert.Equal(t, pd.ProtectionDomain.RebalanceNetworkThrottlingInKbps, a1)
+	assert.Equal(t, pd.ProtectionDomain.VTreeMigrationNetworkThrottlingInKbps, a1)
+	assert.Equal(t, pd.ProtectionDomain.ProtectedMaintenanceModeNetworkThrottlingInKbps, b)
+	assert.Equal(t, pd.ProtectionDomain.OverallIoNetworkThrottlingInKbps, c1)
 }

--- a/inttests/protectiondomain_test.go
+++ b/inttests/protectiondomain_test.go
@@ -222,7 +222,11 @@ func testRfCacheProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
 	assert.Nil(t, err)
 
 	p := types.PDRCModeRead
-	err = pd.SetRfcacheParams(types.PDRfCacheParams{p, 16, 64})
+	err = pd.SetRfcacheParams(types.PDRfCacheParams{
+		RfCacheOperationalMode: p,
+		RfCachePageSizeKb:      16,
+		RfCacheMaxIoSizeKb:     64,
+	})
 	assert.Nil(t, err)
 	err = pd.Refresh()
 	assert.Nil(t, err)
@@ -233,7 +237,7 @@ func testRfCacheProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
 
 	err = pd.EnableRfcache()
 	assert.Nil(t, err)
-	err = pd.SetRfcacheParams(types.PDRfCacheParams{"", 4, 0})
+	err = pd.SetRfcacheParams(types.PDRfCacheParams{RfCachePageSizeKb: 4, RfCacheMaxIoSizeKb: 0})
 	assert.Nil(t, err)
 	err = pd.Refresh()
 	assert.Nil(t, err)
@@ -242,7 +246,7 @@ func testRfCacheProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
 	assert.Equal(t, pd.ProtectionDomain.RfCachePageSizeKb, 4)
 	assert.Equal(t, pd.ProtectionDomain.RfCacheMaxIoSizeKb, 64)
 
-	err = pd.SetRfcacheParams(types.PDRfCacheParams{"", 16, 32})
+	err = pd.SetRfcacheParams(types.PDRfCacheParams{RfCachePageSizeKb: 16, RfCacheMaxIoSizeKb: 32})
 	assert.Nil(t, err)
 	err = pd.Refresh()
 	assert.Nil(t, err)
@@ -255,7 +259,11 @@ func testRfCacheProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
 func testNwLimitsProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
 	oldPd := *pd.ProtectionDomain
 	a, b, c := 10*1024, 16*1024, 0
-	err := pd.SetSdsNetworkLimits(types.SdsNetworkLimitParams{nil, nil, &a, &b, &c})
+	err := pd.SetSdsNetworkLimits(types.SdsNetworkLimitParams{
+		VTreeMigrationNetworkThrottlingInKbps:           &a,
+		ProtectedMaintenanceModeNetworkThrottlingInKbps: &b,
+		OverallIoNetworkThrottlingInKbps:                &c,
+	})
 	assert.Nil(t, err)
 	err = pd.Refresh()
 	assert.Nil(t, err)
@@ -266,7 +274,12 @@ func testNwLimitsProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) 
 	assert.Equal(t, pd.ProtectionDomain.OverallIoNetworkThrottlingInKbps, c)
 
 	a1, c1 := 64*1024, 100*1024
-	err = pd.SetSdsNetworkLimits(types.SdsNetworkLimitParams{&a1, &a1, &a1, nil, &c1})
+	err = pd.SetSdsNetworkLimits(types.SdsNetworkLimitParams{
+		RebuildNetworkThrottlingInKbps:        &a1,
+		RebalanceNetworkThrottlingInKbps:      &a1,
+		VTreeMigrationNetworkThrottlingInKbps: &a1,
+		OverallIoNetworkThrottlingInKbps:      &c1,
+	})
 	assert.Nil(t, err)
 	err = pd.Refresh()
 	assert.Nil(t, err)

--- a/inttests/protectiondomain_test.go
+++ b/inttests/protectiondomain_test.go
@@ -253,14 +253,14 @@ func testRfCacheProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
 }
 
 func testNwLimitsProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
-	old_pd := *pd.ProtectionDomain
+	oldPd := *pd.ProtectionDomain
 	a, b, c := 10*1024, 16*1024, 0
 	err := pd.SetSdsNetworkLimits(types.SdsNetworkLimitParams{nil, nil, &a, &b, &c})
 	assert.Nil(t, err)
 	err = pd.Refresh()
 	assert.Nil(t, err)
-	assert.Equal(t, pd.ProtectionDomain.RebuildNetworkThrottlingInKbps, old_pd.RebuildNetworkThrottlingInKbps)
-	assert.Equal(t, pd.ProtectionDomain.RebalanceNetworkThrottlingInKbps, old_pd.RebalanceNetworkThrottlingInKbps)
+	assert.Equal(t, pd.ProtectionDomain.RebuildNetworkThrottlingInKbps, oldPd.RebuildNetworkThrottlingInKbps)
+	assert.Equal(t, pd.ProtectionDomain.RebalanceNetworkThrottlingInKbps, oldPd.RebalanceNetworkThrottlingInKbps)
 	assert.Equal(t, pd.ProtectionDomain.VTreeMigrationNetworkThrottlingInKbps, a)
 	assert.Equal(t, pd.ProtectionDomain.ProtectedMaintenanceModeNetworkThrottlingInKbps, b)
 	assert.Equal(t, pd.ProtectionDomain.OverallIoNetworkThrottlingInKbps, c)

--- a/inttests/protectiondomain_test.go
+++ b/inttests/protectiondomain_test.go
@@ -205,6 +205,8 @@ func TestCRUDProtectionDomain(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, pd.ProtectionDomain.ProtectionDomainState, "Active")
 
+	testFGLMCacheProtectionDomain(t, pd)
+
 	// check that finding pd by name yields same struct as refreshing
 	pdByName, err3 := system.FindProtectionDomainByName(newName)
 	assert.Nil(t, err3)
@@ -213,6 +215,23 @@ func TestCRUDProtectionDomain(t *testing.T) {
 	// delete pd
 	err = pd.Delete()
 	assert.Nil(t, err)
+}
+
+func testFGLMCacheProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
+	err := pd.DisableFGLMcache()
+	assert.Nil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, pd.ProtectionDomain.FglMetadataCacheEnabled, false)
+
+	err = pd.SetDefaultFGLMcacheSize(1024)
+	assert.Nil(t, err)
+	err = pd.EnableFGLMcache()
+	assert.Nil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, pd.ProtectionDomain.FglMetadataCacheEnabled, true)
+	assert.Equal(t, pd.ProtectionDomain.FglDefaultMetadataCacheSize, 1024)
 }
 
 func testRfCacheProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {

--- a/protectiondomain.go
+++ b/protectiondomain.go
@@ -64,7 +64,7 @@ func (s *System) CreateProtectionDomain(name string) (string, error) {
 	return pd.ID, nil
 }
 
-// GetProtectionDomainEx fetches a ProtectionDomain by ID
+// GetProtectionDomainEx fetches a ProtectionDomain by ID with embedded client
 func (s *System) GetProtectionDomainEx(id string) (*ProtectionDomain, error) {
 	defer TimeSpent("GetProtectionDomainEx", time.Now())
 	pdResp, err := s.FindProtectionDomainByID(id)

--- a/protectiondomain.go
+++ b/protectiondomain.go
@@ -280,19 +280,3 @@ func (pd *ProtectionDomain) DisableRfcache() error {
 	path := "/api/instances/ProtectionDomain::%s/action/disableSdsRfcache"
 	return pd.setParam(path, &types.EmptyPayload{})
 }
-
-// // Set Read RAM Cache Size for all SDS in Protection Domain
-// // No read parameter
-// func (pd *ProtectionDomain) SetRmCacheSize() error {
-// 	path := "/api/instances/ProtectionDomain::%s/action/setSdsRmcacheSize"
-// 	return pd.setParam(path, &types.EmptyPayload{})
-// }
-
-// // Enable / Disable Read RAM Cache for all SDS in Protection Domain
-// // No read parameter
-// func (pd *ProtectionDomain) SetRmCache(enable bool) error {
-// 	path := "/api/instances/ProtectionDomain::%s/action/setSdsRmcacheEnabled"
-// 	return pd.setParam(path, map[string]string{
-// 		"rmcacheEnabled": types.GetBoolType(enable),
-// 	})
-// }

--- a/protectiondomain.go
+++ b/protectiondomain.go
@@ -180,6 +180,7 @@ func (s *System) FindProtectionDomain(
 	return nil, errors.New("Couldn't find protection domain")
 }
 
+// FindProtectionDomainByID returns the ProtectionDomain having a particular ID
 func (s *System) FindProtectionDomainByID(id string) (*types.ProtectionDomain, error) {
 	defer TimeSpent("FindProtectionDomainByID", time.Now())
 
@@ -194,6 +195,7 @@ func (s *System) FindProtectionDomainByID(id string) (*types.ProtectionDomain, e
 	return pds[0], nil
 }
 
+// FindProtectionDomainByName returns the ProtectionDomain having a particular name
 func (s *System) FindProtectionDomainByName(name string) (*types.ProtectionDomain, error) {
 	defer TimeSpent("FindProtectionDomainByName", time.Now())
 
@@ -209,6 +211,7 @@ func (s *System) FindProtectionDomainByName(name string) (*types.ProtectionDomai
 	return s.FindProtectionDomainByID(id)
 }
 
+// SetName sets the name of the pd
 func (pd *ProtectionDomain) SetName(name string) error {
 	path := "/api/instances/ProtectionDomain::%s/action/setProtectionDomainName"
 	nameParam := types.ProtectionDomainParam{
@@ -217,6 +220,7 @@ func (pd *ProtectionDomain) SetName(name string) error {
 	return pd.setParam(path, nameParam)
 }
 
+// Refresh reads and stores current values of the pd
 func (pd *ProtectionDomain) Refresh() error {
 	defer TimeSpent("Refresh Protection Domain", time.Now())
 
@@ -232,30 +236,24 @@ func (pd *ProtectionDomain) Refresh() error {
 	return nil
 }
 
+// SetRfcacheParams sets the Read Flash Cache params of the pd
 func (pd *ProtectionDomain) SetRfcacheParams(params types.PDRfCacheParams) error {
-	p, err := params.ToMap()
-	if err != nil {
-		return err
-	}
 	path := "/api/instances/ProtectionDomain::%s/action/setRfcacheParameters"
-	return pd.setParam(path, p)
+	return pd.setParam(path, params)
 }
 
+// SetSdsNetworkLimits sets IOPS limits on all SDS under the pd
 func (pd *ProtectionDomain) SetSdsNetworkLimits(params types.SdsNetworkLimitParams) error {
 	path := "/api/instances/ProtectionDomain::%s/action/setSdsNetworkLimits"
-	p, err := params.ToMap()
-	if err != nil {
-		return err
-	}
-	return pd.setParam(path, p)
+	return pd.setParam(path, params)
 }
 
-func (pd *ProtectionDomain) setParam(path string, param interface{}) error {
+func (pd *ProtectionDomain) setParam(path string, param any) error {
 	link := fmt.Sprintf(path, pd.ProtectionDomain.ID)
 	return pd.client.getJSONWithRetry(http.MethodPost, link, param, nil)
 }
 
-// Activate Protection domain
+// Activate activates the Protection domain
 func (pd *ProtectionDomain) Activate(forceActivate bool) error {
 	path := "/api/instances/ProtectionDomain::%s/action/activateProtectionDomain"
 	return pd.setParam(path, map[string]string{
@@ -263,7 +261,7 @@ func (pd *ProtectionDomain) Activate(forceActivate bool) error {
 	})
 }
 
-// Inactivate Protection domain
+// InActivate disables the Protection domain
 func (pd *ProtectionDomain) InActivate(forceShutDown bool) error {
 	path := "/api/instances/ProtectionDomain::%s/action/inactivateProtectionDomain"
 	return pd.setParam(path, map[string]string{
@@ -271,13 +269,13 @@ func (pd *ProtectionDomain) InActivate(forceShutDown bool) error {
 	})
 }
 
-// Enable SDS Rfcache for entire Protection Domain
+// EnableRfcache enables SDS Read Flash cache for entire Protection Domain
 func (pd *ProtectionDomain) EnableRfcache() error {
 	path := "/api/instances/ProtectionDomain::%s/action/enableSdsRfcache"
 	return pd.setParam(path, &types.EmptyPayload{})
 }
 
-// Disable SDS Rfcache for entire Protection Domain
+// DisableRfcache disables SDS Read Flash cache for entire Protection Domain
 func (pd *ProtectionDomain) DisableRfcache() error {
 	path := "/api/instances/ProtectionDomain::%s/action/disableSdsRfcache"
 	return pd.setParam(path, &types.EmptyPayload{})

--- a/protectiondomain.go
+++ b/protectiondomain.go
@@ -67,17 +67,11 @@ func (s *System) CreateProtectionDomain(name string) (string, error) {
 // GetProtectionDomainEx fetches a ProtectionDomain by ID
 func (s *System) GetProtectionDomainEx(id string) (*ProtectionDomain, error) {
 	defer TimeSpent("GetProtectionDomainEx", time.Now())
-
-	path := fmt.Sprintf("/api/instances/ProtectionDomain::%s", id)
-
-	pdResp := types.ProtectionDomain{}
-	err := s.client.getJSONWithRetry(
-		http.MethodGet, path, &types.EmptyPayload{}, &pdResp)
+	pdResp, err := s.FindProtectionDomainByID(id)
 	if err != nil {
 		return nil, err
 	}
-
-	return NewProtectionDomainEx(s.client, &pdResp), nil
+	return NewProtectionDomainEx(s.client, pdResp), nil
 }
 
 // DeleteProtectionDomain will delete a protection domain
@@ -282,19 +276,19 @@ func (pd *ProtectionDomain) DisableRfcache() error {
 	return pd.setParam(path, &types.EmptyPayload{})
 }
 
-// DisableFGLMcache disables SDS Read Flash cache for entire Protection Domain
+// DisableFGLMcache disables Fine Granularity Metadata cache for the Protection Domain
 func (pd *ProtectionDomain) DisableFGLMcache() error {
 	path := "/api/instances/ProtectionDomain::%s/action/disableFglMetadataCache"
 	return pd.setParam(path, &types.EmptyPayload{})
 }
 
-// EnableFGLMcache disables SDS Read Flash cache for entire Protection Domain
+// EnableFGLMcache enables Fine Granularity Metadata cache for the Protection Domain
 func (pd *ProtectionDomain) EnableFGLMcache() error {
 	path := "/api/instances/ProtectionDomain::%s/action/enableFglMetadataCache"
 	return pd.setParam(path, &types.EmptyPayload{})
 }
 
-// SetDefaultFGLMcacheSize disables SDS Read Flash cache for entire Protection Domain
+// SetDefaultFGLMcacheSize sets the default FGL Metadata for all SDSs under the Protection Domain
 func (pd *ProtectionDomain) SetDefaultFGLMcacheSize(cacheSizeInMB int) error {
 	path := "/api/instances/ProtectionDomain::%s/action/setDefaultFglMetadataCacheSize"
 	return pd.setParam(path, map[string]string{

--- a/protectiondomain.go
+++ b/protectiondomain.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	types "github.com/dell/goscaleio/types/v1"
@@ -279,4 +280,24 @@ func (pd *ProtectionDomain) EnableRfcache() error {
 func (pd *ProtectionDomain) DisableRfcache() error {
 	path := "/api/instances/ProtectionDomain::%s/action/disableSdsRfcache"
 	return pd.setParam(path, &types.EmptyPayload{})
+}
+
+// DisableFGLMcache disables SDS Read Flash cache for entire Protection Domain
+func (pd *ProtectionDomain) DisableFGLMcache() error {
+	path := "/api/instances/ProtectionDomain::%s/action/disableFglMetadataCache"
+	return pd.setParam(path, &types.EmptyPayload{})
+}
+
+// EnableFGLMcache disables SDS Read Flash cache for entire Protection Domain
+func (pd *ProtectionDomain) EnableFGLMcache() error {
+	path := "/api/instances/ProtectionDomain::%s/action/enableFglMetadataCache"
+	return pd.setParam(path, &types.EmptyPayload{})
+}
+
+// SetDefaultFGLMcacheSize disables SDS Read Flash cache for entire Protection Domain
+func (pd *ProtectionDomain) SetDefaultFGLMcacheSize(cacheSizeInMB int) error {
+	path := "/api/instances/ProtectionDomain::%s/action/setDefaultFglMetadataCacheSize"
+	return pd.setParam(path, map[string]string{
+		"cacheSizeInMB": strconv.Itoa(cacheSizeInMB),
+	})
 }

--- a/types/v1/protectionDomainTypes.go
+++ b/types/v1/protectionDomainTypes.go
@@ -1,66 +1,43 @@
 package goscaleio
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 )
 
-type PflexParams interface {
-	ToMap() (map[string]string, error)
-}
-
-// type PDRfCachePageSize int
-
-// const (
-// 	PDRfCachePageSize4  PDRfCachePageSize = 4
-// 	PDRfCachePageSize8  PDRfCachePageSize = 8
-// 	PDRfCachePageSize16 PDRfCachePageSize = 16
-// 	PDRfCachePageSize32 PDRfCachePageSize = 32
-// 	PDRfCachePageSize64 PDRfCachePageSize = 64
-// )
-
-// func GetPDRfCachePageSize(i int) (error, PDRfCachePageSize){
-// 	switch i {
-// 		4:
-// 	}
-// }
-
-// type PDRfCacheIOSize int
-
-// const (
-// 	PDRfCacheIOSize32  PDRfCacheIOSize = 32
-// 	PDRfCacheIOSize64  PDRfCacheIOSize = 64
-// 	PDRfCacheIOSize126 PDRfCacheIOSize = 126
-// 	PDRfCacheIOSize16  PDRfCacheIOSize = 16
-// )
-
+// PDRfCacheParams is used to manipulate Read Flash Cache settings of a protection domain
 type PDRfCacheParams struct {
-	RfCacheOperationalMode PDRfCacheOpMode `json:"rfcacheOperationMode"`
-	RfCachePageSizeKb      int             `json:"pageSizeKb"`
-	RfCacheMaxIoSizeKb     int             `json:"maxIOSizeKb"`
+	RfCacheOperationalMode PDRfCacheOpMode
+	RfCachePageSizeKb      int
+	RfCacheMaxIoSizeKb     int
 }
 
-func (params PDRfCacheParams) ToMap() (map[string]string, error) {
+// MarshalJSON implements a custom json marshalling
+func (params PDRfCacheParams) MarshalJSON() ([]byte, error) {
+	b := []byte("")
 	m := make(map[string]string)
-	dict := map[int]bool{4: true, 8: true, 16: true, 32: true, 64: true}
 	if params.RfCachePageSizeKb != 0 {
-		if _, ok := dict[params.RfCachePageSizeKb]; !ok {
-			return m, fmt.Errorf("")
+		acceptedVals := map[int]bool{4: true, 8: true, 16: true, 32: true, 64: true}
+		if _, ok := acceptedVals[params.RfCachePageSizeKb]; !ok {
+			return b, fmt.Errorf("RfCachePageSizeKb must be a power of 2 in range [4,64]")
 		}
 		m["pageSizeKb"] = strconv.Itoa(params.RfCachePageSizeKb)
 	}
 	if params.RfCacheMaxIoSizeKb != 0 {
-		if size := params.RfCachePageSizeKb; !(size == 16 || size == 32 || size == 64 || size == 126) {
-			return m, fmt.Errorf("")
+		acceptedVals := map[int]bool{16: true, 32: true, 64: true, 126: true}
+		if _, ok := acceptedVals[params.RfCachePageSizeKb]; !ok {
+			return b, fmt.Errorf("RfCacheMaxIoSizeKb must be a power of 2 in range [16,126]")
 		}
 		m["maxIOSizeKb"] = strconv.Itoa(params.RfCacheMaxIoSizeKb)
 	}
 	if params.RfCacheOperationalMode != "" {
 		m["rfcacheOperationMode"] = string(params.RfCacheOperationalMode)
 	}
-	return m, nil
+	return json.Marshal(m)
 }
 
+// GetRfCacheParams is a function to extract RF cache params from a protection domain
 func (pd *ProtectionDomain) GetRfCacheParams() PDRfCacheParams {
 	return PDRfCacheParams{
 		RfCacheOperationalMode: pd.RfCacheOperationalMode,
@@ -69,15 +46,17 @@ func (pd *ProtectionDomain) GetRfCacheParams() PDRfCacheParams {
 	}
 }
 
+// SdsNetworkLimitParams is used to set IOPS limits on all SDS of a protection domain
 type SdsNetworkLimitParams struct {
-	RebuildNetworkThrottlingInKbps                  *int `json:"rebuildLimitInKbps"`
-	RebalanceNetworkThrottlingInKbps                *int `json:"rebalanceLimitInKbps"`
-	VTreeMigrationNetworkThrottlingInKbps           *int `json:"vtreeMigrationLimitInKbps"`
-	ProtectedMaintenanceModeNetworkThrottlingInKbps *int `json:"protectedMaintenanceModeLimitInKbps"`
-	OverallIoNetworkThrottlingInKbps                *int `json:"overallLimitInKbps"`
+	RebuildNetworkThrottlingInKbps                  *int
+	RebalanceNetworkThrottlingInKbps                *int
+	VTreeMigrationNetworkThrottlingInKbps           *int
+	ProtectedMaintenanceModeNetworkThrottlingInKbps *int
+	OverallIoNetworkThrottlingInKbps                *int
 }
 
-func (params SdsNetworkLimitParams) ToMap() (map[string]string, error) {
+// MarshalJSON implements a custom json marshalling
+func (params SdsNetworkLimitParams) MarshalJSON() ([]byte, error) {
 	m := make(map[string]string)
 	if size := params.RebuildNetworkThrottlingInKbps; size != nil {
 		m["rebuildLimitInKbps"] = strconv.Itoa(*size)
@@ -94,5 +73,16 @@ func (params SdsNetworkLimitParams) ToMap() (map[string]string, error) {
 	if size := params.OverallIoNetworkThrottlingInKbps; size != nil {
 		m["overallLimitInKbps"] = strconv.Itoa(*size)
 	}
-	return m, nil
+	return json.Marshal(m)
+}
+
+// GetNwLimitParams is a function to extract IOPS limit params from a protection domain
+func (pd *ProtectionDomain) GetNwLimitParams() SdsNetworkLimitParams {
+	return SdsNetworkLimitParams{
+		RebuildNetworkThrottlingInKbps:                  &(pd.RebuildNetworkThrottlingInKbps),
+		RebalanceNetworkThrottlingInKbps:                &(pd.RebalanceNetworkThrottlingInKbps),
+		VTreeMigrationNetworkThrottlingInKbps:           &(pd.VTreeMigrationNetworkThrottlingInKbps),
+		ProtectedMaintenanceModeNetworkThrottlingInKbps: &(pd.ProtectedMaintenanceModeNetworkThrottlingInKbps),
+		OverallIoNetworkThrottlingInKbps:                &(pd.OverallIoNetworkThrottlingInKbps),
+	}
 }

--- a/types/v1/protectionDomainTypes.go
+++ b/types/v1/protectionDomainTypes.go
@@ -1,0 +1,98 @@
+package goscaleio
+
+import (
+	"fmt"
+	"strconv"
+)
+
+type PflexParams interface {
+	ToMap() (map[string]string, error)
+}
+
+// type PDRfCachePageSize int
+
+// const (
+// 	PDRfCachePageSize4  PDRfCachePageSize = 4
+// 	PDRfCachePageSize8  PDRfCachePageSize = 8
+// 	PDRfCachePageSize16 PDRfCachePageSize = 16
+// 	PDRfCachePageSize32 PDRfCachePageSize = 32
+// 	PDRfCachePageSize64 PDRfCachePageSize = 64
+// )
+
+// func GetPDRfCachePageSize(i int) (error, PDRfCachePageSize){
+// 	switch i {
+// 		4:
+// 	}
+// }
+
+// type PDRfCacheIOSize int
+
+// const (
+// 	PDRfCacheIOSize32  PDRfCacheIOSize = 32
+// 	PDRfCacheIOSize64  PDRfCacheIOSize = 64
+// 	PDRfCacheIOSize126 PDRfCacheIOSize = 126
+// 	PDRfCacheIOSize16  PDRfCacheIOSize = 16
+// )
+
+type PDRfCacheParams struct {
+	RfCacheOperationalMode PDRfCacheOpMode `json:"rfcacheOperationMode"`
+	RfCachePageSizeKb      int             `json:"pageSizeKb"`
+	RfCacheMaxIoSizeKb     int             `json:"maxIOSizeKb"`
+}
+
+func (params PDRfCacheParams) ToMap() (map[string]string, error) {
+	m := make(map[string]string)
+	dict := map[int]bool{4: true, 8: true, 16: true, 32: true, 64: true}
+	if params.RfCachePageSizeKb != 0 {
+		if _, ok := dict[params.RfCachePageSizeKb]; !ok {
+			return m, fmt.Errorf("")
+		}
+		m["pageSizeKb"] = strconv.Itoa(params.RfCachePageSizeKb)
+	}
+	if params.RfCacheMaxIoSizeKb != 0 {
+		if size := params.RfCachePageSizeKb; !(size == 16 || size == 32 || size == 64 || size == 126) {
+			return m, fmt.Errorf("")
+		}
+		m["maxIOSizeKb"] = strconv.Itoa(params.RfCacheMaxIoSizeKb)
+	}
+	if params.RfCacheOperationalMode != "" {
+		m["rfcacheOperationMode"] = string(params.RfCacheOperationalMode)
+	}
+	return m, nil
+}
+
+func (pd *ProtectionDomain) GetRfCacheParams() PDRfCacheParams {
+	return PDRfCacheParams{
+		RfCacheOperationalMode: pd.RfCacheOperationalMode,
+		RfCachePageSizeKb:      pd.RfCachePageSizeKb,
+		RfCacheMaxIoSizeKb:     pd.RfCacheMaxIoSizeKb,
+	}
+}
+
+type SdsNetworkLimitParams struct {
+	RebuildNetworkThrottlingInKbps                  *int `json:"rebuildLimitInKbps"`
+	RebalanceNetworkThrottlingInKbps                *int `json:"rebalanceLimitInKbps"`
+	VTreeMigrationNetworkThrottlingInKbps           *int `json:"vtreeMigrationLimitInKbps"`
+	ProtectedMaintenanceModeNetworkThrottlingInKbps *int `json:"protectedMaintenanceModeLimitInKbps"`
+	OverallIoNetworkThrottlingInKbps                *int `json:"overallLimitInKbps"`
+}
+
+func (params SdsNetworkLimitParams) ToMap() (map[string]string, error) {
+	m := make(map[string]string)
+	if size := params.RebuildNetworkThrottlingInKbps; size != nil {
+		m["rebuildLimitInKbps"] = strconv.Itoa(*size)
+	}
+	if size := params.RebalanceNetworkThrottlingInKbps; size != nil {
+		m["rebalanceLimitInKbps"] = strconv.Itoa(*size)
+	}
+	if size := params.VTreeMigrationNetworkThrottlingInKbps; size != nil {
+		m["vtreeMigrationLimitInKbps"] = strconv.Itoa(*size)
+	}
+	if size := params.ProtectedMaintenanceModeNetworkThrottlingInKbps; size != nil {
+		m["protectedMaintenanceModeLimitInKbps"] = strconv.Itoa(*size)
+	}
+	if size := params.OverallIoNetworkThrottlingInKbps; size != nil {
+		m["overallLimitInKbps"] = strconv.Itoa(*size)
+	}
+	return m, nil
+}

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -279,7 +279,7 @@ type ProtectionDomain struct {
 	SdrSdsConnectivityInfo      PDConnInfo `json:"sdrSdsConnectivityInfo"`
 	ReplicationCapacityMaxRatio *int       `json:"replicationCapacityMaxRatio"`
 
-	// Network throttling params
+	// SDS Network throttling params
 	RebuildNetworkThrottlingInKbps                   int  `json:"rebuildNetworkThrottlingInKbps"`
 	RebalanceNetworkThrottlingInKbps                 int  `json:"rebalanceNetworkThrottlingInKbps"`
 	OverallIoNetworkThrottlingInKbps                 int  `json:"overallIoNetworkThrottlingInKbps"`


### PR DESCRIPTION
# Description

Add more functions to a protection domain. The functions are:

1. Update name
2. Update SDS IOPS Limits
3. Update SDS Read Flash Params
4. Enable, disable and update FGL Metadata caching
5. Delete

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

I have used the newly added integration tests to test.
```sh
root@lglap049:~/goscaleio# make int-test
The SDC is not installed
All of the drv_cfg tests cannot be run
Starting tests
=== RUN   TestCRUDProtectionDomain
--- PASS: TestCRUDProtectionDomain (0.70s)
PASS
coverage: 13.8% of statements in github.com/dell/goscaleio
ok      github.com/dell/goscaleio/inttests      0.775s
root@lglap049:~/goscaleio# 
```

<details>
<summary>Full Test results</summary>

```sh
root@lglap049:~/goscaleio# make int-test
The SDC is not installed
All of the drv_cfg tests cannot be run
Starting tests
=== RUN   TestGetDevices
--- PASS: TestGetDevices (0.12s)
=== RUN   TestGetDeviceByAttribute
--- PASS: TestGetDeviceByAttribute (0.32s)
=== RUN   TestGetDeviceByAttributeInvalid
--- PASS: TestGetDeviceByAttributeInvalid (0.31s)
=== RUN   TestAddDeviceInvalid
--- PASS: TestAddDeviceInvalid (0.14s)
=== RUN   TestGetDrvCfgGUID
    drv_cfg_test.go:39: PowerFlex SDC is not installed. Cannot validate DrvCfg functionality
--- SKIP: TestGetDrvCfgGUID (0.00s)
=== RUN   TestGetDrvCfgGUIDSDCNotInstalled
--- PASS: TestGetDrvCfgGUIDSDCNotInstalled (0.00s)
=== RUN   TestGetDrvCfgSystems
    drv_cfg_test.go:79: PowerFlex SDC is not installed. Cannot validate DrvCfg functionality
--- SKIP: TestGetDrvCfgSystems (0.00s)
=== RUN   TestGetDrvCfgSystemsSDCNotInstalled
--- PASS: TestGetDrvCfgSystemsSDCNotInstalled (0.00s)
=== RUN   TestGetDrvCfgQueryRescan
    drv_cfg_test.go:111: PowerFlex SDC is not installed. Cannot validate DrvCfg functionality
--- SKIP: TestGetDrvCfgQueryRescan (0.00s)
=== RUN   TestGetDrvCfgQueryRescanSDCNotInstalled
--- PASS: TestGetDrvCfgQueryRescanSDCNotInstalled (0.00s)
=== RUN   TestGetProtectionDomains
--- PASS: TestGetProtectionDomains (0.09s)
=== RUN   TestGetProtectionDomainByName
--- PASS: TestGetProtectionDomainByName (0.18s)
=== RUN   TestGetProtectionDomainByID
--- PASS: TestGetProtectionDomainByID (0.19s)
=== RUN   TestGetProtectionDomainByNameInvalid
--- PASS: TestGetProtectionDomainByNameInvalid (0.09s)
=== RUN   TestGetProtectionDomainByIDInvalid
--- PASS: TestGetProtectionDomainByIDInvalid (0.08s)
=== RUN   TestCreateDeleteProtectionDomain
--- PASS: TestCreateDeleteProtectionDomain (0.21s)
=== RUN   TestCRUDProtectionDomain
--- PASS: TestCRUDProtectionDomain (0.68s)
=== RUN   TestGetPeerMDMs
    replication_test.go:70: no client connection to replication target system
--- SKIP: TestGetPeerMDMs (0.03s)
=== RUN   TestGetTargetSystem
    replication_test.go:131: no client connection to replication target system
--- SKIP: TestGetTargetSystem (0.00s)
=== RUN   TestGetProtectionDomain
--- PASS: TestGetProtectionDomain (0.17s)
=== RUN   TestTargetProtectionDomain
    replication_test.go:163: no client connection to replication target system
--- SKIP: TestTargetProtectionDomain (0.00s)
=== RUN   TestStoragePools
    replication_test.go:184: no client connection to replication target system
--- SKIP: TestStoragePools (0.00s)
=== RUN   TestLocateVolumesToBeReplicated
    replication_test.go:196: no client connection to replication target system
--- SKIP: TestLocateVolumesToBeReplicated (0.00s)
=== RUN   TestCreateReplicationConsistencyGroup
    replication_test.go:229: no client connection to replication target system
--- SKIP: TestCreateReplicationConsistencyGroup (0.00s)
=== RUN   TestGetReplicationConsistencyGroups
    replication_test.go:252: no client connection to replication target system
--- SKIP: TestGetReplicationConsistencyGroups (0.00s)
=== RUN   TestAddReplicationPair
    replication_test.go:272: no client connection to replication target system
--- SKIP: TestAddReplicationPair (0.00s)
=== RUN   TestQueryReplicationPairs
    replication_test.go:317: no client connection to replication target system
--- SKIP: TestQueryReplicationPairs (0.00s)
=== RUN   TestQueryReplicationPairsStatistics
    replication_test.go:333: no client connection to replication target system
--- SKIP: TestQueryReplicationPairsStatistics (0.00s)
=== RUN   TestCreateReplicationConsistencyGroupSnapshot
    replication_test.go:361: no client connection to replication target system
--- SKIP: TestCreateReplicationConsistencyGroupSnapshot (0.00s)
=== RUN   TestSnapshotRetrieval
    replication_test.go:374: no client connection to replication target system
--- SKIP: TestSnapshotRetrieval (0.00s)
=== RUN   TestExecuteFailoverOnReplicationGroup
    replication_test.go:406: no client connection to replication target system
--- SKIP: TestExecuteFailoverOnReplicationGroup (0.00s)
=== RUN   TestExecuteRestoreOnReplicationGroup
    replication_test.go:417: no client connection to replication target system
--- SKIP: TestExecuteRestoreOnReplicationGroup (0.00s)
=== RUN   TestExecuteSwitchoverOnReplicationGroup
    replication_test.go:430: no client connection to replication target system
--- SKIP: TestExecuteSwitchoverOnReplicationGroup (0.00s)
=== RUN   TestExecuteReverseOnReplicationGroup
    replication_test.go:443: no client connection to replication target system
--- SKIP: TestExecuteReverseOnReplicationGroup (0.00s)
=== RUN   TestExecutePauseOnReplicationGroup
    replication_test.go:456: no client connection to replication target system
--- SKIP: TestExecutePauseOnReplicationGroup (0.00s)
=== RUN   TestExecuteResumeOnReplicationGroup
    replication_test.go:469: no client connection to replication target system
--- SKIP: TestExecuteResumeOnReplicationGroup (0.00s)
=== RUN   TestResizeReplicationPair
    replication_test.go:479: no client connection to replication target system
--- SKIP: TestResizeReplicationPair (0.00s)
=== RUN   TestRemoveReplicationPairFromVolume
    replication_test.go:536: no client connection to replication target system
--- SKIP: TestRemoveReplicationPairFromVolume (0.00s)
=== RUN   TestFreezeReplcationGroup
    replication_test.go:567: no client connection to replication target system
--- SKIP: TestFreezeReplcationGroup (0.00s)
=== RUN   TestRemoveReplicationConsistencyGroup
    replication_test.go:580: no client connection to replication target system
--- SKIP: TestRemoveReplicationConsistencyGroup (0.00s)
=== RUN   TestGetSdcs
--- PASS: TestGetSdcs (0.08s)
=== RUN   TestGetSdcByAttribute
--- PASS: TestGetSdcByAttribute (0.22s)
=== RUN   TestGetSdcByAttributeInvalid
--- PASS: TestGetSdcByAttributeInvalid (0.19s)
=== RUN   TestGetSdcStatistics
--- PASS: TestGetSdcStatistics (0.13s)
=== RUN   TestGetSdcVolumes
--- PASS: TestGetSdcVolumes (0.13s)
=== RUN   TestFindSdcVolumes
--- PASS: TestFindSdcVolumes (0.14s)
=== RUN   TestChangeSdcName
--- PASS: TestChangeSdcName (0.14s)
=== RUN   TestGetSDSs
--- PASS: TestGetSDSs (0.17s)
=== RUN   TestGetSDSByAttribute
--- PASS: TestGetSDSByAttribute (0.33s)
=== RUN   TestGetSDSByAttributeInvalid
--- PASS: TestGetSDSByAttributeInvalid (0.31s)
=== RUN   TestCreateSdsInvalid
--- PASS: TestCreateSdsInvalid (0.43s)
=== RUN   TestCreateSdsParamsInvalid
--- PASS: TestCreateSdsParamsInvalid (0.44s)
=== RUN   TestCompareSdsIDApi
--- PASS: TestCompareSdsIDApi (0.25s)
=== RUN   TestCompareSdsAllApi
--- PASS: TestCompareSdsAllApi (0.18s)
=== RUN   TestDeleteSds
--- PASS: TestDeleteSds (0.13s)
=== RUN   TestSetSDSIPRole
--- PASS: TestSetSDSIPRole (0.13s)
=== RUN   TestRemoveSDSIP
--- PASS: TestRemoveSDSIP (0.12s)
=== RUN   TestSetSdsName
--- PASS: TestSetSdsName (0.12s)
=== RUN   TestSetSdsPort
--- PASS: TestSetSdsPort (0.13s)
=== RUN   TestGetStoragePools
--- PASS: TestGetStoragePools (0.17s)
=== RUN   TestGetStoragePoolByName
--- PASS: TestGetStoragePoolByName (0.27s)
=== RUN   TestGetStoragePoolByID
--- PASS: TestGetStoragePoolByID (0.25s)
=== RUN   TestGetStoragePoolByNameInvalid
--- PASS: TestGetStoragePoolByNameInvalid (0.14s)
=== RUN   TestGetStoragePoolByIDInvalid
--- PASS: TestGetStoragePoolByIDInvalid (0.13s)
=== RUN   TestGetStoragePoolStatistics
--- PASS: TestGetStoragePoolStatistics (0.15s)
=== RUN   TestGetInstanceStoragePool
--- PASS: TestGetInstanceStoragePool (0.28s)
=== RUN   TestCreateDeleteStoragePool
--- PASS: TestCreateDeleteStoragePool (0.24s)
=== RUN   TestGetSDSStoragePool
--- PASS: TestGetSDSStoragePool (0.15s)
=== RUN   TestModifyStoragePoolName
--- PASS: TestModifyStoragePoolName (0.12s)
=== RUN   TestStoragePoolMediaType
    storagepool_test.go:256: 
                Error Trace:    storagepool_test.go:256
                Error:          Expected nil, but got: &goscaleio.Error{Message:"Could not find Storage Pool", HTTPStatusCode:500, ErrorCode:171, ErrorDetails:[]goscaleio.ErrorMessageDetails(nil)}
                Test:           TestStoragePoolMediaType
--- FAIL: TestStoragePoolMediaType (0.12s)
=== RUN   TestEnableRFCache
    storagepool_test.go:264: 
                Error Trace:    storagepool_test.go:264
                Error:          Expected nil, but got: &goscaleio.Error{Message:"Could not find Storage Pool", HTTPStatusCode:500, ErrorCode:171, ErrorDetails:[]goscaleio.ErrorMessageDetails(nil)}
                Test:           TestEnableRFCache
--- FAIL: TestEnableRFCache (0.14s)
=== RUN   TestDisableRFCache
    storagepool_test.go:272: 
                Error Trace:    storagepool_test.go:272
                Error:          Expected nil, but got: &goscaleio.Error{Message:"Could not find Storage Pool", HTTPStatusCode:500, ErrorCode:171, ErrorDetails:[]goscaleio.ErrorMessageDetails(nil)}
                Test:           TestDisableRFCache
--- FAIL: TestDisableRFCache (0.11s)
=== RUN   TestModifyRmCache
--- PASS: TestModifyRmCache (0.16s)
=== RUN   TestGetAllStoragePoolsApi
--- PASS: TestGetAllStoragePoolsApi (0.12s)
=== RUN   TestGetStoragePoolByIDApi
--- PASS: TestGetStoragePoolByIDApi (0.27s)
=== RUN   TestGetSystems
--- PASS: TestGetSystems (0.03s)
=== RUN   TestGetSingleSystemID
--- PASS: TestGetSingleSystemID (0.07s)
=== RUN   TestGetSingleSystemByIDInvalid
system &{0xc0003daf00 0xc0000a4198} err %!s(<nil>)
    system_test.go:60: 
                Error Trace:    system_test.go:60
                Error:          Expected value not to be nil.
                Test:           TestGetSingleSystemByIDInvalid
    system_test.go:61: 
                Error Trace:    system_test.go:61
                Error:          Expected nil, but got: &goscaleio.System{System:(*goscaleio.System)(0xc0003daf00), client:(*goscaleio.Client)(0xc0000a4198)}
                Test:           TestGetSingleSystemByIDInvalid
--- FAIL: TestGetSingleSystemByIDInvalid (0.03s)
=== RUN   TestGetSingleSystemByIDName
--- PASS: TestGetSingleSystemByIDName (0.03s)
=== RUN   TestGetSystemStatistics
--- PASS: TestGetSystemStatistics (0.09s)
=== RUN   TestGetAllUsers
--- PASS: TestGetAllUsers (0.09s)
=== RUN   TestGetVolumes
--- PASS: TestGetVolumes (0.71s)
=== RUN   TestFindVolumeID
[FindVolumeID] volumeID: edb27ade00000006
--- PASS: TestFindVolumeID (0.24s)
=== RUN   TestCreateDeleteVolume
--- PASS: TestCreateDeleteVolume (0.23s)
=== RUN   TestCreateVolumeExistingName
--- PASS: TestCreateVolumeExistingName (0.41s)
=== RUN   TestDeleteNonExistentVolume
--- PASS: TestDeleteNonExistentVolume (0.27s)
=== RUN   TestCreateDeleteSnapshot
--- PASS: TestCreateDeleteSnapshot (0.42s)
=== RUN   TestGetVolumeVtree
--- PASS: TestGetVolumeVtree (0.29s)
=== RUN   TestGetVolumeStatistics
--- PASS: TestGetVolumeStatistics (0.27s)
=== RUN   TestResizeVolume
--- PASS: TestResizeVolume (0.33s)
=== RUN   TestMapQueryUnmapVolume
--- PASS: TestMapQueryUnmapVolume (0.44s)
=== RUN   TestMapQueryUnmapSnapshot
--- PASS: TestMapQueryUnmapSnapshot (0.80s)
=== RUN   TestCreateInstanceVolume
--- PASS: TestCreateInstanceVolume (0.15s)
=== RUN   TestCreateInstanceVolumeInvalidSize
--- PASS: TestCreateInstanceVolumeInvalidSize (0.07s)
=== RUN   TestGetInstanceVolume
[FindVolumeID] volumeID: edb27aec00000006
[FindVolumeID] volumeID: 
--- PASS: TestGetInstanceVolume (5.38s)
=== RUN   TestSetMappedSdcLimitsInvalid
--- PASS: TestSetMappedSdcLimitsInvalid (0.26s)
=== RUN   TestLockUnlockAutoSnapshot
--- PASS: TestLockUnlockAutoSnapshot (0.66s)
=== RUN   TestSetVolumeAccessModeLimit
--- PASS: TestSetVolumeAccessModeLimit (0.31s)
=== RUN   TestSetSnapshotSecurity
Will wait for 60 sec so that the retention period expires and snapshot can be deleted
--- PASS: TestSetSnapshotSecurity (60.73s)
=== RUN   TestSetVolumeMappingAccessMode
    volume_test.go:739: 
                Error Trace:    volume_test.go:739
                Error:          Expected nil, but got: &goscaleio.Error{Message:"Could not find the SDC", HTTPStatusCode:500, ErrorCode:80, ErrorDetails:[]goscaleio.ErrorMessageDetails(nil)}
                Test:           TestSetVolumeMappingAccessMode
--- FAIL: TestSetVolumeMappingAccessMode (0.74s)
=== RUN   TestSetVolumeUseRmCache
--- PASS: TestSetVolumeUseRmCache (0.28s)
=== RUN   TestSetCompressionMethod
--- PASS: TestSetCompressionMethod (0.30s)
FAIL
coverage: 59.3% of statements in github.com/dell/goscaleio
exit status 1
FAIL    github.com/dell/goscaleio/inttests      82.952s
Makefile:11: recipe for target 'int-test' failed
make: *** [int-test] Error 1
root@lglap049:~/goscaleio# 
```
</details>
