### PR TITLE
added missing functionality for storage pool enhancement

### DIFF
--- a/inttests/storagepool_test.go
+++ b/inttests/storagepool_test.go
@@ -287,36 +287,36 @@ func TestStoragePoolAdditionalFunctionality(t *testing.T) {
 	assert.Nil(t, err)
 	pool, _ := domain.FindStoragePool(poolID, "", "")
 	//check the value
-	assert.Equal(t, pool.ZeroPaddingEnabled,false)
+	assert.Equal(t, pool.ZeroPaddingEnabled, false)
 
 	// Now enable the padding
 	err = domain.EnableOrDisableZeroPadding(poolID, "true")
 	assert.Nil(t, err)
 	pool, _ = domain.FindStoragePool(poolID, "", "")
 	//check the value
-	assert.Equal(t, pool.ZeroPaddingEnabled,true)
+	assert.Equal(t, pool.ZeroPaddingEnabled, true)
 
 	//Modify Replication Journal Capacity to make it 36
 	err = domain.SetReplicationJournalCapacity(poolID, "36")
 	assert.Nil(t, err)
 	pool, _ = domain.FindStoragePool(poolID, "", "")
 	//check the value
-	assert.Equal(t, pool.ReplicationCapacityMaxRatio,36)
+	assert.Equal(t, pool.ReplicationCapacityMaxRatio, 36)
 
 	//Again Modify Replication Journal Capacity to make it 0 else storage pool can't be deleted
 	err = domain.SetReplicationJournalCapacity(poolID, "0")
 	assert.Nil(t, err)
 	pool, _ = domain.FindStoragePool(poolID, "", "")
 	//again check the value
-	assert.Equal(t, pool.ReplicationCapacityMaxRatio,0)
+	assert.Equal(t, pool.ReplicationCapacityMaxRatio, 0)
 
 	//set the capacity threshold for the storage pool
 	err = domain.SetCapacityAlertThreshold(poolID, "77", "87")
 	assert.Nil(t, err)
 	pool, _ = domain.FindStoragePool(poolID, "", "")
 	//check the value
-	assert.Equal(t, pool.CapacityAlertHighThreshold,77)
-	assert.Equal(t, pool.CapacityAlertCriticalThreshold,87)
+	assert.Equal(t, pool.CapacityAlertHighThreshold, 77)
+	assert.Equal(t, pool.CapacityAlertCriticalThreshold, 87)
 
 	//Set the protected maintenance mode
 	protectedMaintenanceModeParam := &types.ProtectedMaintenanceModeParam{
@@ -327,22 +327,22 @@ func TestStoragePoolAdditionalFunctionality(t *testing.T) {
 	assert.Nil(t, err)
 	pool, _ = domain.FindStoragePool(poolID, "", "")
 	//check the value
-	assert.Equal(t, pool.ProtectedMaintenanceModeIoPriorityPolicy,"favorAppIos")
-	assert.Equal(t, pool.ProtectedMaintenanceModeIoPriorityNumOfConcurrentIosPerDevice,18)
+	assert.Equal(t, pool.ProtectedMaintenanceModeIoPriorityPolicy, "favorAppIos")
+	assert.Equal(t, pool.ProtectedMaintenanceModeIoPriorityNumOfConcurrentIosPerDevice, 18)
 
 	//set rebalance enablement value
 	err = domain.SetRebalanceEnabled(poolID, "true")
 	assert.Nil(t, err)
 	pool, _ = domain.FindStoragePool(poolID, "", "")
 	//check the value
-	assert.Equal(t, pool.RebalanceEnabled,true)
+	assert.Equal(t, pool.RebalanceEnabled, true)
 
 	//Again set rebalance enablement value
 	err = domain.SetRebalanceEnabled(poolID, "false")
 	assert.Nil(t, err)
 	pool, _ = domain.FindStoragePool(poolID, "", "")
 	//check the value
-	assert.Equal(t, pool.RebalanceEnabled,false)
+	assert.Equal(t, pool.RebalanceEnabled, false)
 
 	//set the rebalance IO priority policy for the storage pool
 	protectedMaintenanceModeParam = &types.ProtectedMaintenanceModeParam{
@@ -353,8 +353,8 @@ func TestStoragePoolAdditionalFunctionality(t *testing.T) {
 	assert.Nil(t, err)
 	//check the value
 	pool, _ = domain.FindStoragePool(poolID, "", "")
-	assert.Equal(t, pool.RebalanceioPriorityPolicy,"limitNumOfConcurrentIos")
-	assert.Equal(t, pool.RebalanceioPriorityNumOfConcurrentIosPerDevice,13)
+	assert.Equal(t, pool.RebalanceioPriorityPolicy, "limitNumOfConcurrentIos")
+	assert.Equal(t, pool.RebalanceioPriorityNumOfConcurrentIosPerDevice, 13)
 	assert.Nil(t, err)
 
 	//Set vtree migration IO priority policy
@@ -367,37 +367,37 @@ func TestStoragePoolAdditionalFunctionality(t *testing.T) {
 	assert.Nil(t, err)
 	//check the value
 	pool, _ = domain.FindStoragePool(poolID, "", "")
-	assert.Equal(t, pool.VtreeMigrationIoPriorityPolicy,"favorAppIos")
-	assert.Equal(t, pool.VtreeMigrationIoPriorityNumOfConcurrentIosPerDevice,12)
-	assert.Equal(t, pool.VtreeMigrationIoPriorityBwLimitPerDeviceInKbps,1030)
+	assert.Equal(t, pool.VtreeMigrationIoPriorityPolicy, "favorAppIos")
+	assert.Equal(t, pool.VtreeMigrationIoPriorityNumOfConcurrentIosPerDevice, 12)
+	assert.Equal(t, pool.VtreeMigrationIoPriorityBwLimitPerDeviceInKbps, 1030)
 
-	//set the spare percentage 
+	//set the spare percentage
 	err = domain.SetSparePercentage(poolID, "67")
 	assert.Nil(t, err)
 	//check the value
 	pool, _ = domain.FindStoragePool(poolID, "", "")
-	assert.Equal(t, pool.SparePercentage,67)
+	assert.Equal(t, pool.SparePercentage, 67)
 
 	//set the Rmcache write handling mode
 	err = domain.SetRMcacheWriteHandlingMode(poolID, "Cached")
 	assert.Nil(t, err)
 	//check the value
 	pool, _ = domain.FindStoragePool(poolID, "", "")
-	assert.Equal(t, pool.RmCacheWriteHandlingMode,"Cached")
+	assert.Equal(t, pool.RmCacheWriteHandlingMode, "Cached")
 
 	//set the rebuild enablemenent value
 	err = domain.SetRebuildEnabled(poolID, "false")
 	assert.Nil(t, err)
 	//check the value
 	pool, _ = domain.FindStoragePool(poolID, "", "")
-	assert.Equal(t, pool.RebuildEnabled,false)
+	assert.Equal(t, pool.RebuildEnabled, false)
 
 	// set the number of parallel rebuild rebalance jobs per device
 	err = domain.SetRebuildRebalanceParallelismParam(poolID, "9")
 	assert.Nil(t, err)
 	//check the value
 	pool, _ = domain.FindStoragePool(poolID, "", "")
-	assert.Equal(t, pool.NumofParallelRebuildRebalanceJobsPerDevice,9)
+	assert.Equal(t, pool.NumofParallelRebuildRebalanceJobsPerDevice, 9)
 
 	//enable fragmentation
 	err = domain.EnableFragmentation(poolID)

--- a/inttests/storagepool_test.go
+++ b/inttests/storagepool_test.go
@@ -252,7 +252,23 @@ func TestModifyStoragePoolName(t *testing.T) {
 func TestStoragePoolMediaType(t *testing.T) {
 	domain := getProtectionDomain(t)
 	assert.NotNil(t, domain)
-	_, err := domain.ModifyStoragePoolMedia("b9b0be6600000004", "SSD")
+
+	poolName := fmt.Sprintf("%s-%s", testPrefix, "StoragePool")
+
+	sp := &types.StoragePoolParam{
+		Name:      poolName,
+		MediaType: "HDD",
+	}
+
+	// create the storage pool
+	poolID, err := domain.CreateStoragePool(sp)
+	assert.Nil(t, err)
+	assert.NotNil(t, poolID)
+	_, err = domain.ModifyStoragePoolMedia(poolID, "SSD")
+	assert.Nil(t, err)
+
+	//delete the pool
+	err = domain.DeleteStoragePool(poolName)
 	assert.Nil(t, err)
 }
 
@@ -260,7 +276,22 @@ func TestStoragePoolMediaType(t *testing.T) {
 func TestEnableRFCache(t *testing.T) {
 	domain := getProtectionDomain(t)
 	assert.NotNil(t, domain)
-	_, err := domain.EnableRFCache("b9b0be6400000003")
+
+	poolName := fmt.Sprintf("%s-%s", testPrefix, "StoragePool")
+
+	sp := &types.StoragePoolParam{
+		Name:      poolName,
+		MediaType: "HDD",
+	}
+
+	// create the storage pool
+	poolID, err := domain.CreateStoragePool(sp)
+	assert.Nil(t, err)
+	assert.NotNil(t, poolID)
+	_, err = domain.EnableRFCache(poolID)
+	assert.Nil(t, err)
+	//delete the pool
+	err = domain.DeleteStoragePool(poolName)
 	assert.Nil(t, err)
 }
 
@@ -416,7 +447,22 @@ func TestStoragePoolAdditionalFunctionality(t *testing.T) {
 func TestDisableRFCache(t *testing.T) {
 	domain := getProtectionDomain(t)
 	assert.NotNil(t, domain)
-	_, err := domain.DisableRFCache("b9b0be6400000003")
+
+	poolName := fmt.Sprintf("%s-%s", testPrefix, "StoragePool")
+
+	sp := &types.StoragePoolParam{
+		Name:      poolName,
+		MediaType: "HDD",
+	}
+
+	// create the storage pool
+	poolID, err := domain.CreateStoragePool(sp)
+	assert.Nil(t, err)
+	assert.NotNil(t, poolID)
+	_, err = domain.DisableRFCache(poolID)
+	assert.Nil(t, err)
+	//delete the pool
+	err = domain.DeleteStoragePool(poolName)
 	assert.Nil(t, err)
 }
 

--- a/inttests/storagepool_test.go
+++ b/inttests/storagepool_test.go
@@ -264,6 +264,126 @@ func TestEnableRFCache(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+// Modify TestEnableOrDisableZeroPadEnabled
+func TestEnableOrDisableZeroPadEnabled(t *testing.T) {
+	domain := getProtectionDomain(t)
+
+	assert.NotNil(t, domain)
+	err := domain.EnableOrDisableZeroPadding("c98e4e1500000001", "false")
+	assert.Nil(t, err)
+}
+
+// Modify Replication Journal Capacity
+func TestSetReplicationJournalCapacity(t *testing.T) {
+	domain := getProtectionDomain(t)
+	assert.NotNil(t, domain)
+	err := domain.SetReplicationJournalCapacity("c98e4e1500000001", "36")
+	assert.Nil(t, err)
+}
+
+// Modify Capacity Alert Threshold
+func TestSetCapacityAlertThreshold(t *testing.T) {
+	domain := getProtectionDomain(t)
+	assert.NotNil(t, domain)
+	err := domain.SetCapacityAlertThreshold("c98e4e1500000001", "77", "87")
+	assert.Nil(t, err)
+}
+
+// Modify Protected Maintenance Mode Io Priority Policy
+func TestSetProtectedMaintenanceModeIoPriorityPolicy(t *testing.T) {
+	domain := getProtectionDomain(t)
+	protectedMaintenanceModeParam := &types.ProtectedMaintenanceModeParam{
+		Policy:                      "favorAppIos",
+		NumOfConcurrentIosPerDevice: "18",
+	}
+	assert.NotNil(t, domain)
+	err := domain.SetProtectedMaintenanceModeIoPriorityPolicy("c98e4e1500000001", protectedMaintenanceModeParam)
+	assert.Nil(t, err)
+}
+
+// Modify Rebalance Enabled
+func TestSetRebalanceEnabled(t *testing.T) {
+	domain := getProtectionDomain(t)
+	assert.NotNil(t, domain)
+	err := domain.SetRebalanceEnabled("c98e4e1500000001", "true")
+	assert.Nil(t, err)
+}
+
+// Modify Rebalance Io Priority Policy
+func TestSetRebalanceIoPriorityPolicy(t *testing.T) {
+	domain := getProtectionDomain(t)
+	protectedMaintenanceModeParam := &types.ProtectedMaintenanceModeParam{
+		Policy:                      "favorAppIos",
+		NumOfConcurrentIosPerDevice: "12",
+		BwLimitPerDeviceInKbps:      "1030",
+	}
+	assert.NotNil(t, domain)
+	err := domain.SetRebalanceIoPriorityPolicy("c98e4e1500000001", protectedMaintenanceModeParam)
+	assert.Nil(t, err)
+}
+
+// Modify VTree Migration IO Priority Policy
+func TestSetVTreeMigrationIOPriorityPolicy(t *testing.T) {
+	domain := getProtectionDomain(t)
+	protectedMaintenanceModeParam := &types.ProtectedMaintenanceModeParam{
+		Policy:                      "favorAppIos",
+		NumOfConcurrentIosPerDevice: "12",
+		BwLimitPerDeviceInKbps:      "1030",
+	}
+	assert.NotNil(t, domain)
+	err := domain.SetVTreeMigrationIOPriorityPolicy("c98e4e1500000001", protectedMaintenanceModeParam)
+	assert.Nil(t, err)
+}
+
+// Modify Spare Percentage
+func TestSetSparePercentage(t *testing.T) {
+	domain := getProtectionDomain(t)
+	assert.NotNil(t, domain)
+	err := domain.SetSparePercentage("c98e4e1500000001", "38")
+	assert.Nil(t, err)
+}
+
+// Modify RMcache Write Handling Mode
+func TestSetRMcacheWriteHandlingMode(t *testing.T) {
+	domain := getProtectionDomain(t)
+	assert.NotNil(t, domain)
+	err := domain.SetRMcacheWriteHandlingMode("c98e4e1500000001", "Cached")
+	assert.Nil(t, err)
+}
+
+// Modify Rebuild Enabled
+func TestSetRebuildEnabled(t *testing.T) {
+	domain := getProtectionDomain(t)
+	assert.NotNil(t, domain)
+	err := domain.SetRebuildEnabled("c98e4e1500000001", "false")
+	assert.Nil(t, err)
+}
+
+// Modify Rebuild Rebalance Parallelism
+func TestSetRebuildRebalanceParallelismParam(t *testing.T) {
+	domain := getProtectionDomain(t)
+	assert.NotNil(t, domain)
+	err := domain.SetRebuildRebalanceParallelismParam("c98e4e1500000001", "9")
+	assert.Nil(t, err)
+}
+
+// Modify Enable Fragmentation
+func TestEnableFragmentation(t *testing.T) {
+	domain := getProtectionDomain(t)
+	assert.NotNil(t, domain)
+
+	err := domain.EnableFragmentation("c98e4e1500000001")
+	assert.Nil(t, err)
+}
+
+// Modify Disble Fragmentation
+func TestDisbleFragmentation(t *testing.T) {
+	domain := getProtectionDomain(t)
+	assert.NotNil(t, domain)
+	err := domain.DisableFragmentation("c98e4e1500000001")
+	assert.Nil(t, err)
+}
+
 // Modify TestDisableRFCache
 func TestDisableRFCache(t *testing.T) {
 	domain := getProtectionDomain(t)

--- a/storagepool.go
+++ b/storagepool.go
@@ -127,6 +127,178 @@ func (pd *ProtectionDomain) EnableRFCache(ID string) (string, error) {
 	return spResp.ID, nil
 }
 
+// EnableOrDisableZeroPadding Enables / disables zero padding
+func (pd *ProtectionDomain) EnableOrDisableZeroPadding(ID string, zeroPadValue string) error {
+
+	zeroPaddedParam := &types.StoragePoolZeroPadEnabled{
+		ZeroPadEnabled: zeroPadValue,
+	}
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setZeroPaddingPolicy", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, zeroPaddedParam, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetReplicationJournalCapacity Sets replication journal capacity
+func (pd *ProtectionDomain) SetReplicationJournalCapacity(ID string, replicationJournalCapacity string) error {
+
+	replicationJournalCapacityParam := &types.ReplicationJournalCapacityParam{
+		ReplicationJournalCapacityMaxRatio: replicationJournalCapacity,
+	}
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setReplicationJournalCapacity", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, replicationJournalCapacityParam, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetCapacityAlertThreshold Sets capacity alert threshold - high and critical
+func (pd *ProtectionDomain) SetCapacityAlertThreshold(ID string, highValue string, criticalValue string) error {
+	capacityAlertThreshold := &types.CapacityAlertThresholdParam{
+		CapacityAlertHighThresholdPercent:     highValue,
+		CapacityAlertCriticalThresholdPercent: criticalValue,
+	}
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setCapacityAlertThresholds", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, capacityAlertThreshold, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetProtectedMaintenanceModeIoPriorityPolicy sets protected maintenance mode IO priority policy
+func (pd *ProtectionDomain) SetProtectedMaintenanceModeIoPriorityPolicy(ID string, protectedMaintenanceModeParam *types.ProtectedMaintenanceModeParam) error {
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setProtectedMaintenanceModeIoPriorityPolicy", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, protectedMaintenanceModeParam, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetRebalanceEnabled sets rebalance enabled.
+func (pd *ProtectionDomain) SetRebalanceEnabled(ID string, rebalanceEnabledValue string) error {
+	rebalanceEnabledParam := &types.RebalanceEnabledParam{
+		RebalanceEnabled: rebalanceEnabledValue,
+	}
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setRebalanceEnabled", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, rebalanceEnabledParam, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetRebalanceIoPriorityPolicy Sets rebalance I/O priority policy
+func (pd *ProtectionDomain) SetRebalanceIoPriorityPolicy(ID string, protectedMaintenanceModeParam *types.ProtectedMaintenanceModeParam) error {
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setRebalanceIoPriorityPolicy", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, protectedMaintenanceModeParam, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetVTreeMigrationIOPriorityPolicy Sets V-Tree migration I/O priority policy
+func (pd *ProtectionDomain) SetVTreeMigrationIOPriorityPolicy(ID string, protectedMaintenanceModeParam *types.ProtectedMaintenanceModeParam) error {
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setVTreeMigrationIoPriorityPolicy", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, protectedMaintenanceModeParam, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetSparePercentage Sets spare percentage
+func (pd *ProtectionDomain) SetSparePercentage(ID string, sparePercentageValue string) error {
+	percentageParam := &types.SparePercentageParam{
+		SparePercentage: sparePercentageValue,
+	}
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setSparePercentage", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, percentageParam, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetRMcacheWriteHandlingMode Sets RMcache write handling mode
+func (pd *ProtectionDomain) SetRMcacheWriteHandlingMode(ID string, writeHandlingModeValue string) error {
+	writeHandlingParam := &types.RmcacheWriteHandlingModeParam{
+		RmcacheWriteHandlingMode: writeHandlingModeValue,
+	}
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setRmcacheWriteHandlingMode", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, writeHandlingParam, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetRebuildEnabled Sets Rebuild Enabled
+func (pd *ProtectionDomain) SetRebuildEnabled(ID string, rebuildEnabledValue string) error {
+	rebuildEnabled := &types.RebuildEnabledParam{
+		RebuildEnabled: rebuildEnabledValue,
+	}
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setRebuildEnabled", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, rebuildEnabled, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetRebuildRebalanceParallelismParam Sets rebuild/rebalance parallelism
+func (pd *ProtectionDomain) SetRebuildRebalanceParallelismParam(ID string, limitValue string) error {
+	rebuildRebalanceParam := &types.RebuildRebalanceParallelismParam{
+		Limit: limitValue,
+	}
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setRebuildRebalanceParallelism", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, rebuildRebalanceParam, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// EnableFragmentation enables fragmentation
+func (pd *ProtectionDomain) EnableFragmentation(ID string) error {
+	payload := &types.FragmentationParam{}
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/enableFragmentation", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, payload, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DisableFragmentation disables fragmentation
+func (pd *ProtectionDomain) DisableFragmentation(ID string) error {
+	payload := &types.FragmentationParam{}
+	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/disableFragmentation", ID)
+	err := pd.client.getJSONWithRetry(
+		http.MethodPost, path, payload, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // DisableRFCache Disables RFCache
 func (pd *ProtectionDomain) DisableRFCache(ID string) (string, error) {
 

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -634,6 +634,48 @@ type StoragePoolUseRmCache struct {
 type StoragePoolUseRfCache struct {
 }
 
+type StoragePoolZeroPadEnabled struct {
+	ZeroPadEnabled string `json:"zeroPadEnabled"`
+}
+
+type ReplicationJournalCapacityParam struct {
+	ReplicationJournalCapacityMaxRatio string `json:"replicationJournalCapacityMaxRatio"`
+}
+
+type CapacityAlertThresholdParam struct {
+	CapacityAlertHighThresholdPercent     string `json:"capacityAlertHighThresholdPercent"`
+	CapacityAlertCriticalThresholdPercent string `json:"capacityAlertCriticalThresholdPercent"`
+}
+
+type ProtectedMaintenanceModeParam struct {
+	Policy                      string `json:"policy"`
+	NumOfConcurrentIosPerDevice string `json:"numOfConcurrentIosPerDevice,omitempty"`
+	BwLimitPerDeviceInKbps      string `json:"bwLimitPerDeviceInKbps,omitempty"`
+}
+
+type RebalanceEnabledParam struct {
+	RebalanceEnabled string `json:"rebalanceEnabled"`
+}
+
+type SparePercentageParam struct {
+	SparePercentage string `json:"sparePercentage"`
+}
+
+type RmcacheWriteHandlingModeParam struct {
+	RmcacheWriteHandlingMode string `json:"rmcacheWriteHandlingMode"`
+}
+
+type RebuildEnabledParam struct {
+	RebuildEnabled string `json:"rebuildEnabled"`
+}
+
+type RebuildRebalanceParallelismParam struct {
+	Limit string `json:"limit"`
+}
+
+type FragmentationParam struct {
+}
+
 // StoragePoolResp defines struct for StoragePoolResp
 type StoragePoolResp struct {
 	ID string `json:"id"`

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -634,45 +634,55 @@ type StoragePoolUseRmCache struct {
 type StoragePoolUseRfCache struct {
 }
 
+// StoragePoolZeroPadEnabled defines struct for zero Pad Enablement
 type StoragePoolZeroPadEnabled struct {
 	ZeroPadEnabled string `json:"zeroPadEnabled"`
 }
 
+// ReplicationJournalCapacityParam defines struct for Replication Journal Capacity
 type ReplicationJournalCapacityParam struct {
 	ReplicationJournalCapacityMaxRatio string `json:"replicationJournalCapacityMaxRatio"`
 }
 
+// CapacityAlertThresholdParam defines struct for Capacity Alert Threshold
 type CapacityAlertThresholdParam struct {
 	CapacityAlertHighThresholdPercent     string `json:"capacityAlertHighThresholdPercent"`
 	CapacityAlertCriticalThresholdPercent string `json:"capacityAlertCriticalThresholdPercent"`
 }
 
+// ProtectedMaintenanceModeParam defines struct for Protected Maintenance Mode
 type ProtectedMaintenanceModeParam struct {
 	Policy                      string `json:"policy"`
 	NumOfConcurrentIosPerDevice string `json:"numOfConcurrentIosPerDevice,omitempty"`
 	BwLimitPerDeviceInKbps      string `json:"bwLimitPerDeviceInKbps,omitempty"`
 }
 
+// RebalanceEnabledParam defines struct for Rebalance Enablement
 type RebalanceEnabledParam struct {
 	RebalanceEnabled string `json:"rebalanceEnabled"`
 }
 
+// SparePercentageParam defines struct for Spare Percentage
 type SparePercentageParam struct {
 	SparePercentage string `json:"sparePercentage"`
 }
 
+// RmcacheWriteHandlingModeParam defines struct for Rmcache Write Handling Mode
 type RmcacheWriteHandlingModeParam struct {
 	RmcacheWriteHandlingMode string `json:"rmcacheWriteHandlingMode"`
 }
 
+// RebuildEnabledParam defines struct for Rebuild Enablement
 type RebuildEnabledParam struct {
 	RebuildEnabled string `json:"rebuildEnabled"`
 }
 
+// RebuildRebalanceParallelismParam defines struct for Rebuild Rebalance Parallelism
 type RebuildRebalanceParallelismParam struct {
 	Limit string `json:"limit"`
 }
 
+// FragmentationParam defines struct for fragmentation
 type FragmentationParam struct {
 }
 


### PR DESCRIPTION
# Description
This PR includes some more functionality to be added to the storage pool which are as follows :
Enable / disable zero padding - zero padding must be enabled before adding any devices to the storage 
Set replication journal capacity
Set capacity alert thresholds - high and critical threshold percentage
Set protected maintenance mode I/O priority policy
Set rebalance enabled
Set rebalance I/O priority policy
Set V-Tree migration I/O priority policy
Set spare percentage
Set RMcache write handling mode
Enable/Disable rebuilds
Set rebuild/rebalance parallelism
Enable/Disable fragmentation

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
I have written my own test to test the new functionality .
```
Running tool: /usr/local/go/bin/go test -timeout 90m -run ^TestStoragePoolAdditionalFunctionality$ github.com/dell/goscaleio/inttests

ok  	github.com/dell/goscaleio/inttests	0.960s

``` 

```
=== RUN   TestGetStoragePools
--- PASS: TestGetStoragePools (0.16s)
=== RUN   TestGetStoragePoolByName
--- PASS: TestGetStoragePoolByName (0.21s)
=== RUN   TestGetStoragePoolByID
--- PASS: TestGetStoragePoolByID (0.21s)
=== RUN   TestGetStoragePoolByNameInvalid
--- PASS: TestGetStoragePoolByNameInvalid (0.11s)
=== RUN   TestGetStoragePoolByIDInvalid
--- PASS: TestGetStoragePoolByIDInvalid (0.11s)
=== RUN   TestGetStoragePoolStatistics
--- PASS: TestGetStoragePoolStatistics (0.15s)
=== RUN   TestGetInstanceStoragePool
--- PASS: TestGetInstanceStoragePool (0.25s)
=== RUN   TestCreateDeleteStoragePool
--- PASS: TestCreateDeleteStoragePool (0.23s)
=== RUN   TestGetSDSStoragePool
--- PASS: TestGetSDSStoragePool (0.13s)
=== RUN   TestModifyStoragePoolName
--- PASS: TestModifyStoragePoolName (0.10s)
=== RUN   TestStoragePoolMediaType
    storagepool_test.go:256: 
                Error Trace:    storagepool_test.go:256
                Error:          Expected nil, but got: &goscaleio.Error{Message:"Could not find Storage Pool", HTTPStatusCode:500, ErrorCode:171, ErrorDetails:[]goscaleio.ErrorMessageDetails(nil)}
                Test:           TestStoragePoolMediaType
--- FAIL: TestStoragePoolMediaType (0.11s)
=== RUN   TestEnableRFCache
    storagepool_test.go:264: 
                Error Trace:    storagepool_test.go:264
                Error:          Expected nil, but got: &goscaleio.Error{Message:"Could not find Storage Pool", HTTPStatusCode:500, ErrorCode:171, ErrorDetails:[]goscaleio.ErrorMessageDetails(nil)}
                Test:           TestEnableRFCache
--- FAIL: TestEnableRFCache (0.12s)
**=== RUN   TestEnableOrDisableZeroPadEnabled
--- PASS: TestEnableOrDisableZeroPadEnabled (0.94s)**
=== RUN   TestDisableRFCache
    storagepool_test.go:413: 
                Error Trace:    storagepool_test.go:413
                Error:          Expected nil, but got: &goscaleio.Error{Message:"Could not find Storage Pool", HTTPStatusCode:500, ErrorCode:171, ErrorDetails:[]goscaleio.ErrorMessageDetails(nil)}
                Test:           TestDisableRFCache
--- FAIL: TestDisableRFCache (0.12s)
=== RUN   TestModifyRmCache
--- PASS: TestModifyRmCache (0.13s)
=== RUN   TestGetAllStoragePoolsApi
--- PASS: TestGetAllStoragePoolsApi (0.11s)
=== RUN   TestGetStoragePoolByIDApi
--- PASS: TestGetStoragePoolByIDApi (0.17s)
``` 


After fixing the existing test cases . It was previously failing as it was using static ids.
```
=== RUN   TestGetStoragePools
--- PASS: TestGetStoragePools (0.17s)
=== RUN   TestGetStoragePoolByName
--- PASS: TestGetStoragePoolByName (0.23s)
=== RUN   TestGetStoragePoolByID
--- PASS: TestGetStoragePoolByID (0.23s)
=== RUN   TestGetStoragePoolByNameInvalid
--- PASS: TestGetStoragePoolByNameInvalid (0.12s)
=== RUN   TestGetStoragePoolByIDInvalid
--- PASS: TestGetStoragePoolByIDInvalid (0.11s)
=== RUN   TestGetStoragePoolStatistics
--- PASS: TestGetStoragePoolStatistics (0.15s)
=== RUN   TestGetInstanceStoragePool
--- PASS: TestGetInstanceStoragePool (0.26s)
=== RUN   TestCreateDeleteStoragePool
--- PASS: TestCreateDeleteStoragePool (0.23s)
=== RUN   TestGetSDSStoragePool
--- PASS: TestGetSDSStoragePool (0.14s)
=== RUN   TestModifyStoragePoolName
--- PASS: TestModifyStoragePoolName (0.12s)
=== RUN   TestStoragePoolMediaType
--- PASS: TestStoragePoolMediaType (0.20s)
=== RUN   TestEnableRFCache
--- PASS: TestEnableRFCache (0.20s)
=== RUN   TestStoragePoolAdditionalFunctionality
--- PASS: TestStoragePoolAdditionalFunctionality (0.99s)
=== RUN   TestDisableRFCache
--- PASS: TestDisableRFCache (0.21s)
=== RUN   TestModifyRmCache
--- PASS: TestModifyRmCache (0.14s)
=== RUN   TestGetAllStoragePoolsApi
--- PASS: TestGetAllStoragePoolsApi (0.09s)
=== RUN   TestGetStoragePoolByIDApi
--- PASS: TestGetStoragePoolByIDApi (0.18s)
``` 

- [ ] Test A
- [ ] Test B

