### PR TITLE
minute changes in storage pool

### DIFF
--- a/inttests/storagepool_test.go
+++ b/inttests/storagepool_test.go
@@ -342,12 +342,14 @@ func TestStoragePoolAdditionalFunctionality(t *testing.T) {
 	assert.Equal(t, pool.ReplicationCapacityMaxRatio, 0)
 
 	//set the capacity threshold for the storage pool
-	err = domain.SetCapacityAlertThreshold(poolID, "77", "87")
+	capacityAlertThreshold := &types.CapacityAlertThresholdParam{
+		CapacityAlertHighThresholdPercent: "68",
+	}
+	err = domain.SetCapacityAlertThreshold(poolID, capacityAlertThreshold)
 	assert.Nil(t, err)
 	pool, _ = domain.FindStoragePool(poolID, "", "")
 	//check the value
-	assert.Equal(t, pool.CapacityAlertHighThreshold, 77)
-	assert.Equal(t, pool.CapacityAlertCriticalThreshold, 87)
+	assert.Equal(t, pool.CapacityAlertHighThreshold, 68)
 
 	//Set the protected maintenance mode
 	protectedMaintenanceModeParam := &types.ProtectedMaintenanceModeParam{
@@ -431,12 +433,16 @@ func TestStoragePoolAdditionalFunctionality(t *testing.T) {
 	assert.Equal(t, pool.NumofParallelRebuildRebalanceJobsPerDevice, 9)
 
 	//enable fragmentation
-	err = domain.EnableFragmentation(poolID)
+	err = domain.Fragmentation(poolID, true)
 	assert.Nil(t, err)
+	pool, _ = domain.FindStoragePool(poolID, "", "")
+	assert.Equal(t, pool.FragmentationEnabled, true)
 
 	//disable fragmentation
-	err = domain.DisableFragmentation(poolID)
+	err = domain.Fragmentation(poolID, false)
 	assert.Nil(t, err)
+	pool, _ = domain.FindStoragePool(poolID, "", "")
+	assert.Equal(t, pool.FragmentationEnabled, false)
 
 	// finally after all the operations, now delete the pool
 	err = domain.DeleteStoragePool(poolName)

--- a/storagepool.go
+++ b/storagepool.go
@@ -157,12 +157,7 @@ func (pd *ProtectionDomain) SetReplicationJournalCapacity(ID string, replication
 	return nil
 }
 
-// SetCapacityAlertThreshold Sets capacity alert threshold - high and critical
-func (pd *ProtectionDomain) SetCapacityAlertThreshold(ID string, highValue string, criticalValue string) error {
-	capacityAlertThreshold := &types.CapacityAlertThresholdParam{
-		CapacityAlertHighThresholdPercent:     highValue,
-		CapacityAlertCriticalThresholdPercent: criticalValue,
-	}
+func (pd *ProtectionDomain) SetCapacityAlertThreshold(ID string, capacityAlertThreshold *types.CapacityAlertThresholdParam) error {
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setCapacityAlertThresholds", ID)
 	err := pd.client.getJSONWithRetry(
 		http.MethodPost, path, capacityAlertThreshold, nil)
@@ -276,26 +271,25 @@ func (pd *ProtectionDomain) SetRebuildRebalanceParallelismParam(ID string, limit
 }
 
 // EnableFragmentation enables fragmentation
-func (pd *ProtectionDomain) EnableFragmentation(ID string) error {
+func (pd *ProtectionDomain) Fragmentation(ID string, value bool) error {
 	payload := &types.FragmentationParam{}
-	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/enableFragmentation", ID)
-	err := pd.client.getJSONWithRetry(
-		http.MethodPost, path, payload, nil)
-	if err != nil {
-		return err
+	if value {
+		
+		path := fmt.Sprintf("/api/instances/StoragePool::%v/action/enableFragmentation", ID)
+		err := pd.client.getJSONWithRetry(
+			http.MethodPost, path, payload, nil)
+		if err != nil {
+			return err
+		}
+	} else {
+		path := fmt.Sprintf("/api/instances/StoragePool::%v/action/disableFragmentation", ID)
+		err := pd.client.getJSONWithRetry(
+			http.MethodPost, path, payload, nil)
+		if err != nil {
+			return err
+		}
 	}
-	return nil
-}
 
-// DisableFragmentation disables fragmentation
-func (pd *ProtectionDomain) DisableFragmentation(ID string) error {
-	payload := &types.FragmentationParam{}
-	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/disableFragmentation", ID)
-	err := pd.client.getJSONWithRetry(
-		http.MethodPost, path, payload, nil)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/storagepool.go
+++ b/storagepool.go
@@ -270,11 +270,11 @@ func (pd *ProtectionDomain) SetRebuildRebalanceParallelismParam(ID string, limit
 	return nil
 }
 
-// EnableFragmentation enables fragmentation
+// Fragmentation enables or disables fragmentation
 func (pd *ProtectionDomain) Fragmentation(ID string, value bool) error {
 	payload := &types.FragmentationParam{}
 	if value {
-		
+
 		path := fmt.Sprintf("/api/instances/StoragePool::%v/action/enableFragmentation", ID)
 		err := pd.client.getJSONWithRetry(
 			http.MethodPost, path, payload, nil)

--- a/storagepool.go
+++ b/storagepool.go
@@ -157,6 +157,7 @@ func (pd *ProtectionDomain) SetReplicationJournalCapacity(ID string, replication
 	return nil
 }
 
+// SetCapacityAlertThreshold Sets high or critical capacity alert threshold
 func (pd *ProtectionDomain) SetCapacityAlertThreshold(ID string, capacityAlertThreshold *types.CapacityAlertThresholdParam) error {
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setCapacityAlertThresholds", ID)
 	err := pd.client.getJSONWithRetry(

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -683,11 +683,11 @@ type StoragePool struct {
 // StoragePoolParam defines struct for StoragePoolParam
 type StoragePoolParam struct {
 	Name                     string `json:"name"`
-	SparePercentage          int    `json:"sparePercentage,omitempty"`
+	SparePercentage          string `json:"sparePercentage,omitempty"`
 	RebuildEnabled           bool   `json:"rebuildEnabled,omitempty"`
 	RebalanceEnabled         bool   `json:"rebalanceEnabled,omitempty"`
 	ProtectionDomainID       string `json:"protectionDomainId"`
-	ZeroPaddingEnabled       bool   `json:"zeroPaddingEnabled,omitempty"`
+	ZeroPaddingEnabled       string `json:"zeroPaddingEnabled,omitempty"`
 	UseRmcache               string `json:"useRmcache,omitempty"`
 	UseRfcache               string `json:"useRfcache,omitempty"`
 	RmcacheWriteHandlingMode string `json:"rmcacheWriteHandlingMode,omitempty"`
@@ -725,8 +725,8 @@ type ReplicationJournalCapacityParam struct {
 
 // CapacityAlertThresholdParam defines struct for Capacity Alert Threshold
 type CapacityAlertThresholdParam struct {
-	CapacityAlertHighThresholdPercent     string `json:"capacityAlertHighThresholdPercent"`
-	CapacityAlertCriticalThresholdPercent string `json:"capacityAlertCriticalThresholdPercent"`
+	CapacityAlertHighThresholdPercent     string `json:"capacityAlertHighThresholdPercent,omitempty"`
+	CapacityAlertCriticalThresholdPercent string `json:"capacityAlertCriticalThresholdPercent,omitempty"`
 }
 
 // ProtectedMaintenanceModeParam defines struct for Protected Maintenance Mode


### PR DESCRIPTION
# Description

I've done minor changes in some function which I previously wrote in this PR : https://github.com/dell/goscaleio/pull/52.
Also changed the type for zeroPadding and spare percentage of the storage pool.


# GitHub Issues
List the GitHub issues impacted by this PR:
https://github.com/dell/csm/issues/778

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
I ran all the tests in the storagepool_test.go to verify this 
![image](https://user-images.githubusercontent.com/118799587/234217102-811fa912-909a-4ae2-8162-923f95c2cba9.png)

- [ ] Test A
- [ ] Test B
- 

