### PR TITLE
Offload PDRfCacheParams validation to the pflex array

### DIFF
--- a/inttests/protectiondomain_test.go
+++ b/inttests/protectiondomain_test.go
@@ -265,6 +265,15 @@ func testRfCacheProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
 	assert.Equal(t, pd.ProtectionDomain.RfCachePageSizeKb, 4)
 	assert.Equal(t, pd.ProtectionDomain.RfCacheMaxIoSizeKb, 64)
 
+	err = pd.SetRfcacheParams(types.PDRfCacheParams{RfCachePageSizeKb: 8, RfCacheMaxIoSizeKb: 32})
+	assert.Nil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheEnabled, true)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheOperationalMode, p)
+	assert.Equal(t, pd.ProtectionDomain.RfCachePageSizeKb, 8)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheMaxIoSizeKb, 32)
+
 	err = pd.SetRfcacheParams(types.PDRfCacheParams{RfCachePageSizeKb: 16, RfCacheMaxIoSizeKb: 32})
 	assert.Nil(t, err)
 	err = pd.Refresh()

--- a/inttests/protectiondomain_test.go
+++ b/inttests/protectiondomain_test.go
@@ -254,6 +254,19 @@ func testRfCacheProtectionDomain(t *testing.T, pd *goscaleio.ProtectionDomain) {
 	assert.Equal(t, pd.ProtectionDomain.RfCachePageSizeKb, 16)
 	assert.Equal(t, pd.ProtectionDomain.RfCacheMaxIoSizeKb, 64)
 
+	err = pd.SetRfcacheParams(types.PDRfCacheParams{
+		RfCacheOperationalMode: p,
+		RfCachePageSizeKb:      15,
+		RfCacheMaxIoSizeKb:     65,
+	})
+	assert.NotNil(t, err)
+	err = pd.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheEnabled, false)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheOperationalMode, p)
+	assert.Equal(t, pd.ProtectionDomain.RfCachePageSizeKb, 16)
+	assert.Equal(t, pd.ProtectionDomain.RfCacheMaxIoSizeKb, 64)
+
 	err = pd.EnableRfcache()
 	assert.Nil(t, err)
 	err = pd.SetRfcacheParams(types.PDRfCacheParams{RfCachePageSizeKb: 4, RfCacheMaxIoSizeKb: 0})

--- a/types/v1/protectionDomainTypes.go
+++ b/types/v1/protectionDomainTypes.go
@@ -2,7 +2,6 @@ package goscaleio
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 )
 
@@ -15,20 +14,11 @@ type PDRfCacheParams struct {
 
 // MarshalJSON implements a custom json marshalling
 func (params PDRfCacheParams) MarshalJSON() ([]byte, error) {
-	b := []byte("")
 	m := make(map[string]string)
 	if params.RfCachePageSizeKb != 0 {
-		acceptedVals := map[int]bool{4: true, 8: true, 16: true, 32: true, 64: true}
-		if _, ok := acceptedVals[params.RfCachePageSizeKb]; !ok {
-			return b, fmt.Errorf("RfCachePageSizeKb must be a power of 2 in range [4,64]")
-		}
 		m["pageSizeKb"] = strconv.Itoa(params.RfCachePageSizeKb)
 	}
 	if params.RfCacheMaxIoSizeKb != 0 {
-		acceptedVals := map[int]bool{16: true, 32: true, 64: true, 126: true}
-		if _, ok := acceptedVals[params.RfCachePageSizeKb]; !ok {
-			return b, fmt.Errorf("RfCacheMaxIoSizeKb must be a power of 2 in range [16,126]")
-		}
 		m["maxIOSizeKb"] = strconv.Itoa(params.RfCacheMaxIoSizeKb)
 	}
 	if params.RfCacheOperationalMode != "" {


### PR DESCRIPTION
# Description
Offload PDRfCacheParams validation to the pflex array. This will make the Go code compatible with future versions of pflex which may have separate validation.

# GitHub Issues
List the GitHub issues impacted by this PR:
https://github.com/dell/csm/issues/778

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

```
root@lglap049:~/goscaleio# make int-test
The SDC is not installed
All of the drv_cfg tests cannot be run
Starting tests
=== RUN   TestCRUDProtectionDomain
--- PASS: TestCRUDProtectionDomain (0.87s)
PASS
coverage: 12.1% of statements in github.com/dell/goscaleio
ok      github.com/dell/goscaleio/inttests      0.931s
root@lglap049:~/goscaleio#
```

