### PR TITLE
fixed storage pool delete functionality

### DIFF
--- a/storagepool.go
+++ b/storagepool.go
@@ -315,7 +315,7 @@ func (pd *ProtectionDomain) DisableRFCache(ID string) (string, error) {
 // DeleteStoragePool will delete a storage pool
 func (pd *ProtectionDomain) DeleteStoragePool(name string) error {
 	// get the storage pool name
-	pool, err := pd.client.FindStoragePool("", name, "", "")
+	pool, err := pd.FindStoragePool("", name, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description
There was a small issue while deleting the storage pool . As we know, we can create storage pools with same name under different protection domains.

So when we use the same storage pool name for creation under different protection domain, its getting created successfully but causing issue while deleting it.

Defecct link : https://jira.cec.lab.emc.com/browse/TFM-989

# GitHub Issues


List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

I ran the all the tests for storage pool as my changes was in Delete Storagpool function .
![image](https://github.com/dell/goscaleio/assets/118799587/8c5ab0be-2194-4fc7-9f2d-87b39e4b38a9)


- [ ] Test A
- [ ] Test B

