### PR TITLE
NFS: expand filesystem operation added

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -120,3 +120,24 @@ func (s *System) DeleteFileSystem(name string) error {
 
 	return nil
 }
+
+// ModifyFileSystem modifies a file system
+func (s *System) ModifyFileSystem(modifyFsParam *types.FSModify, id string) error {
+	defer TimeSpent("ModifyFileSystem", time.Now())
+
+	fs, err := s.GetFileSystemByIDName(id, "")
+	if err != nil {
+		return err
+	}
+
+	var body *types.FSModify = modifyFsParam
+	path := fmt.Sprintf("/rest/v1/file-systems/%v", fs.ID)
+
+	err = s.client.getJSONWithRetry(http.MethodPatch, path, body, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -1246,6 +1246,12 @@ type FsCreate struct {
 	IsAsyncMTimeEnabled        bool   `json:"is_async_MTime_enabled,omitempty"`
 }
 
+// FSModify defines struct for modify FS
+type FSModify struct {
+	Size        int    `json:"size_total"`
+	Description string `json:"description,omitempty"`
+}
+
 // FileSystemResp defines struct for FileSystemResp
 type FileSystemResp struct {
 	ID string `json:"id"`


### PR DESCRIPTION
# Description
Expand NFS filesystem operation added.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/763 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] unit tests
```
=== RUN   TestCreateFileSystem
=== RUN   TestCreateFileSystem/success
=== RUN   TestCreateFileSystem/bad_request
--- PASS: TestCreateFileSystem (0.00s)
    --- PASS: TestCreateFileSystem/success (0.00s)
    --- PASS: TestCreateFileSystem/bad_request (0.00s)
=== RUN   TestDeleteFileSystem
--- PASS: TestDeleteFileSystem (0.00s)
=== RUN   TestModifyFileSystem
=== RUN   TestModifyFileSystem/#00
=== RUN   TestModifyFileSystem/#01
--- PASS: TestModifyFileSystem (0.00s)
    --- PASS: TestModifyFileSystem/#00 (0.00s)
    --- PASS: TestModifyFileSystem/#01 (0.00s)
```
- [x] integration tests
```
=== RUN   TestGetAllFileSystems
--- PASS: TestGetAllFileSystems (0.29s)
=== RUN   TestGetFileSystemByIDName
--- PASS: TestGetFileSystemByIDName (0.31s)
=== RUN   TestGetFileSystemByNameIDInvalid
--- PASS: TestGetFileSystemByNameIDInvalid (0.29s)
=== RUN   TestCreateDeleteFileSystem
--- PASS: TestCreateDeleteFileSystem (13.86s)
=== RUN   TestModifyFileSystem
--- PASS: TestModifyFileSystem (11.06s)
```