### PR TITLE
Add CreateSnapshotForFileSystem functionality for nfs-support

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -101,6 +101,21 @@ func (s *System) CreateFileSystem(fs *types.FsCreate) (*types.FileSystemResp, er
 	return &fsResponse, nil
 }
 
+// CreateFileSystemSnapshot creates a snapshot for a given file system
+func (s *System) CreateFileSystemSnapshot(createSnapParam *types.CreateFileSystemSnapshotParam, fsID string) (*types.CreateFileSystemSnapshotResponse, error) {
+	defer TimeSpent("CreateFileSystemSnapshot", time.Now())
+
+	path := fmt.Sprintf("/rest/v1/file-systems/%v/snapshot", fsID)
+	snapResponse := types.CreateFileSystemSnapshotResponse{}
+	err := s.client.getJSONWithRetry(
+		http.MethodPost, path, createSnapParam, &snapResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &snapResponse, nil
+}
+
 // DeleteFileSystem deletes a file system
 func (s *System) DeleteFileSystem(name string) error {
 	defer TimeSpent("DeleteFileSystem", time.Now())

--- a/fs.go
+++ b/fs.go
@@ -136,6 +136,26 @@ func (s *System) DeleteFileSystem(name string) error {
 	return nil
 }
 
+// DeleteFileSystemByID deletes a file system by id
+func (s *System) DeleteFileSystemByID(id string) error {
+	defer TimeSpent("DeleteFileSystem", time.Now())
+
+	fs, err := s.GetFileSystemByIDName(id, "")
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/rest/v1/file-systems/%v", fs.ID)
+
+	err = s.client.getJSONWithRetry(
+		http.MethodDelete, path, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ModifyFileSystem modifies a file system
 func (s *System) ModifyFileSystem(modifyFsParam *types.FSModify, id string) error {
 	defer TimeSpent("ModifyFileSystem", time.Now())

--- a/fs.go
+++ b/fs.go
@@ -136,26 +136,6 @@ func (s *System) DeleteFileSystem(name string) error {
 	return nil
 }
 
-// DeleteFileSystemByID deletes a file system by id
-func (s *System) DeleteFileSystemByID(id string) error {
-	defer TimeSpent("DeleteFileSystem", time.Now())
-
-	fs, err := s.GetFileSystemByIDName(id, "")
-	if err != nil {
-		return err
-	}
-
-	path := fmt.Sprintf("/rest/v1/file-systems/%v", fs.ID)
-
-	err = s.client.getJSONWithRetry(
-		http.MethodDelete, path, nil, nil)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // ModifyFileSystem modifies a file system
 func (s *System) ModifyFileSystem(modifyFsParam *types.FSModify, id string) error {
 	defer TimeSpent("ModifyFileSystem", time.Now())

--- a/fs_test.go
+++ b/fs_test.go
@@ -316,6 +316,102 @@ func TestCreateFileSystem(t *testing.T) {
 	}
 }
 
+func TestCreateFileSystemSnapshot(t *testing.T) {
+	type checkFn func(*testing.T, *types.CreateFileSystemSnapshotResponse, error)
+	check := func(fns ...checkFn) []checkFn { return fns }
+
+	hasNoError := func(t *testing.T, resp *types.CreateFileSystemSnapshotResponse, err error) {
+		if err != nil {
+			t.Fatalf("expected no error")
+		}
+	}
+
+	hasError := func(t *testing.T, resp *types.CreateFileSystemSnapshotResponse, err error) {
+		if err == nil {
+			t.Fatalf("expected error")
+		}
+	}
+
+	checkResp := func(snapId string) func(t *testing.T, resp *types.CreateFileSystemSnapshotResponse, err error) {
+		return func(t *testing.T, resp *types.CreateFileSystemSnapshotResponse, err error) {
+			assert.Equal(t, snapId, resp.ID)
+		}
+	}
+
+	tests := map[string]func(t *testing.T) (*httptest.Server, []checkFn){
+		"success": func(t *testing.T) (*httptest.Server, []checkFn) {
+
+			href := fmt.Sprintf("/rest/v1/file-systems/%v/snapshot", "64366a19-54e8-1544-f3d7-2a50fb1ccff3")
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Fatal(fmt.Errorf("wrong method. Expected %s; but got %s", http.MethodGet, r.Method))
+				}
+
+				if r.URL.Path != href {
+					t.Fatal(fmt.Errorf("wrong path. Expected %s; but got %s", href, r.URL.Path))
+				}
+
+				resp := types.CreateFileSystemSnapshotResponse{
+					ID: "64366a19-54e8-1544-f3d7-2a50fb1ccff3",
+				}
+
+				respData, err := json.Marshal(resp)
+				if err != nil {
+					t.Fatal(err)
+				}
+				fmt.Fprintln(w, string(respData))
+			}))
+			return ts, check(hasNoError, checkResp("64366a19-54e8-1544-f3d7-2a50fb1ccff3"))
+		},
+		"bad request": func(t *testing.T) (*httptest.Server, []checkFn) {
+			href := fmt.Sprintf("/rest/v1/file-systems/%v/snapshot", "64366a19-54e8-1544-f3d7-2a50fb1ccff3")
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Fatal(fmt.Errorf("wrong method. Expected %s; but got %s", http.MethodGet, r.Method))
+				}
+
+				if r.URL.Path != href {
+					t.Fatal(fmt.Errorf("wrong path. Expected %s; but got %s", href, r.URL.Path))
+				}
+
+				http.Error(w, "bad Request", http.StatusBadRequest)
+			}))
+			return ts, check(hasError)
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ts, checkFns := tc(t)
+			defer ts.Close()
+
+			client, err := NewClientWithArgs(ts.URL, "", math.MaxInt64, true, false)
+			client.configConnect.Version = "4.0"
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s := System{
+				client: client,
+			}
+
+			fsID := "64366a19-54e8-1544-f3d7-2a50fb1ccff3"
+
+			fsSnapRequest := &types.CreateFileSystemSnapshotParam{
+				Name: "test-snapshot",
+			}
+
+			resp, err := s.CreateFileSystemSnapshot(fsSnapRequest, fsID)
+			for _, checkFn := range checkFns {
+				checkFn(t, resp, err)
+			}
+
+		})
+	}
+}
+
 func TestDeleteFileSystem(t *testing.T) {
 
 	name := "new-fs"

--- a/inttests/fs_test.go
+++ b/inttests/fs_test.go
@@ -66,6 +66,66 @@ func TestGetAllFileSystems(t *testing.T) {
 	assert.NotZero(t, len(filesystems))
 }
 
+func TestCreateFileSystemSnapshot(t *testing.T) {
+	system := getSystem()
+	assert.NotNil(t, system)
+
+	fsName := fmt.Sprintf("%s-%s", "FS", testPrefix)
+
+	// get protection domain
+	pd := getProtectionDomain(t)
+	assert.NotNil(t, pd)
+
+	// get storage pool
+	pool := getStoragePool(t)
+	assert.NotNil(t, pool)
+	var spID string
+	if pd != nil && pool != nil {
+		sp, _ := pd.FindStoragePool(pool.StoragePool.ID, "", "")
+		assert.NotNil(t, sp)
+		spID = sp.ID
+	}
+
+	// get NAS server ID
+	var nasServerName string
+	if os.Getenv("GOSCALEIO_NASSERVER") != "" {
+		nasServerName = os.Getenv("GOSCALEIO_NASSERVER")
+	}
+	nasServer, err := system.GetNASByIDName("", nasServerName)
+	assert.NotNil(t, nasServer)
+	assert.Nil(t, err)
+
+	fs := &types.FsCreate{
+		Name:          fsName,
+		SizeTotal:     16106127360,
+		StoragePoolID: spID,
+		NasServerID:   nasServer.ID,
+	}
+
+	// create the file system
+	filesystem, err := system.CreateFileSystem(fs)
+	fsID := filesystem.ID
+	assert.Nil(t, err)
+	assert.NotNil(t, fsID)
+
+	snapResp, err := system.CreateFileSystemSnapshot(&types.CreateFileSystemSnapshotParam{
+		Name: "test-snapshot",
+	}, fsID)
+
+	assert.NotNil(t, snapResp)
+	assert.Nil(t, err)
+
+	snap, err := system.GetFileSystemByIDName(snapResp.ID, "")
+	assert.NotNil(t, snap)
+	assert.Nil(t, err)
+
+	err = system.DeleteFileSystem(snap.Name)
+	assert.Nil(t, err)
+	err = system.DeleteFileSystem(fs.Name)
+	assert.Nil(t, err)
+
+}
+
 // TestGetFileSystemByIDName will return specific filesystem by name or ID
 func TestGetFileSystemByIDName(t *testing.T) {
 

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -1290,6 +1290,29 @@ type FileSystem struct {
 	CreatorType                string `json:"creator_type"`
 }
 
+// CreateFileSystemSnapshotParam defines struct for  FileSystem Snapshot Request
+type CreateFileSystemSnapshotParam struct {
+	Name                       string `json:"name,omitempty"`
+	Description                string `json:"description,omitempty"`
+	ExpirationTimestamp        string `json:"expiration_timestamp,omitempty"`
+	AccessType                 string `json:"access_type,omitempty"`
+	AccessPolicy               string `json:"access_policy,omitempty"`
+	LockingPolicy              string `json:"locking_policy,omitempty"`
+	FolderRenamePolicy         string `json:"folder_rename_policy,omitempty"`
+	IsSmbSyncWritesEnabled     bool   `json:"is_smb_sync_writes_enabled,omitempty"`
+	IsSmbNoNotifyEnabled       bool   `json:"is_smb_no_notify_enabled,omitempty"`
+	IsSmbOpLocksEnabled        bool   `json:"is_smb_op_locks_enabled,omitempty"`
+	IsSmbNotifyOnAccessEnabled bool   `json:"is_smb_notify_on_access_enabled,omitempty"`
+	IsSmbNotifyOnWriteEnabled  bool   `json:"is_smb_notify_on_write_enabled,omitempty"`
+	SmbNotifyOnChangeDirDepth  int    `json:"smb_notify_on_change_dir_depth,omitempty"`
+	IsAsyncMTimeEnabled        bool   `json:"is_async_MTime_enabled,omitempty"`
+}
+
+// CreateFileSystemSnapshotResponse defines struct for FileSystem Snapshot Response
+type CreateFileSystemSnapshotResponse struct {
+	ID string `json:"id,omitempty"`
+}
+
 // FsCreate defines struct for creating a PowerFlex FileSystem
 type FsCreate struct {
 	Name                       string `json:"name"`


### PR DESCRIPTION
# Description
This pr adds the  CreateSnapshotForFileSystem functionality for csi-powerflex nfs-support

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/763 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] TestResult
```
root@xxxxx:~/goscaleio# go test -v  -run ^TestCreateFileSystemSnapshot$ github.com/dell/goscaleio/inttests
=== RUN   TestCreateFileSystemSnapshot
--- PASS: TestCreateFileSystemSnapshot (52.45s)
PASS
ok      github.com/dell/goscaleio/inttests      52.764s
```


