### PR TITLE
added rename functionality for MDM and getting VTree details using VTree ID/Volume ID

### DIFF
--- a/inttests/system_test.go
+++ b/inttests/system_test.go
@@ -179,6 +179,45 @@ func TestSwitchClusterModeInvalid(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+// TestRenameMdm modifies MDM name
+func TestRenameMdm(t *testing.T) {
+	// first, get all of the systems
+	allSystems, err := C.GetSystems()
+	assert.Nil(t, err)
+
+	// then try to get the first one returned, explicitly
+	system, err := C.FindSystem(allSystems[0].ID, "", "")
+	assert.Nil(t, err)
+
+	mdmDetails, err1 := system.GetMDMClusterDetails()
+	assert.Nil(t, err1)
+	assert.NotNil(t, mdmDetails)
+
+	payload := types.RenameMdm{
+		ID:      mdmDetails.TiebreakerMdm[0].ID,
+		NewName: "mdm_renamed",
+	}
+
+	err = system.RenameMdm(&payload)
+	assert.Nil(t, err)
+
+	payload = types.RenameMdm{
+		ID:      mdmDetails.TiebreakerMdm[0].ID,
+		NewName: "mdm_renamed",
+	}
+
+	err = system.RenameMdm(&payload)
+	assert.NotNil(t, err)
+
+	payload = types.RenameMdm{
+		ID:      mdmDetails.TiebreakerMdm[0].ID,
+		NewName: "tb_mdm",
+	}
+
+	err = system.RenameMdm(&payload)
+	assert.Nil(t, err)
+}
+
 // TestChangeMDMOwnership modifies primary MDM
 func TestChangeMDMOwnership(t *testing.T) {
 	// first, get all of the systems

--- a/inttests/vtree_test.go
+++ b/inttests/vtree_test.go
@@ -39,3 +39,17 @@ func TestGetVTreeInstances(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Nil(t, allVTrees)
 }
+
+func TestGetVTreeByVolumeID(t *testing.T) {
+	allVTrees, err := C.GetVTrees()
+	assert.Nil(t, err)
+	assert.NotNil(t, allVTrees)
+
+	vTree, err := C.GetVTreeByVolumeID(allVTrees[0].RootVolumes[0])
+	assert.Nil(t, err)
+	assert.NotNil(t, vTree)
+
+	vTree, err = C.GetVTreeByVolumeID(invalidIdentifier)
+	assert.NotNil(t, err)
+	assert.Nil(t, vTree)
+}

--- a/inttests/vtree_test.go
+++ b/inttests/vtree_test.go
@@ -1,0 +1,41 @@
+package inttests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVTrees(t *testing.T) {
+	allVTrees, err := C.GetVTrees()
+	assert.Nil(t, err)
+	assert.NotNil(t, allVTrees)
+}
+
+func TestGetVTreeByID(t *testing.T) {
+	allVTrees, err := C.GetVTrees()
+	assert.Nil(t, err)
+	assert.NotNil(t, allVTrees)
+
+	vTree, err := C.GetVTreeByID(allVTrees[0].ID)
+	assert.Nil(t, err)
+	assert.NotNil(t, vTree)
+
+	vTree, err = C.GetVTreeByID(invalidIdentifier)
+	assert.NotNil(t, err)
+	assert.Nil(t, vTree)
+}
+
+func TestGetVTreeInstances(t *testing.T) {
+	allVTrees, err := C.GetVTrees()
+	assert.Nil(t, err)
+	assert.NotNil(t, allVTrees)
+
+	allVTrees, err = C.GetVTreeInstances([]string{allVTrees[0].ID})
+	assert.Nil(t, err)
+	assert.NotNil(t, allVTrees)
+
+	allVTrees, err = C.GetVTreeInstances([]string{invalidIdentifier})
+	assert.NotNil(t, err)
+	assert.Nil(t, allVTrees)
+}

--- a/system.go
+++ b/system.go
@@ -199,3 +199,16 @@ func (s *System) ChangeMdmOwnerShip(id string) error {
 	}
 	return nil
 }
+
+// RenameMdm modifies name of the MDM
+func (s *System) RenameMdm(renameMdm *types.RenameMdm) error {
+	defer TimeSpent("ChangeMdmOwnerShip", time.Now())
+
+	path := "/api/instances/System/action/renameMdm"
+	err := s.client.getJSONWithRetry(
+		http.MethodPost, path, renameMdm, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -167,6 +167,12 @@ type SwitchClusterMode struct {
 	RemoveTBMdms        []string `json:"removeTBIdList,omitempty"`
 }
 
+// RenameMdm defines struct for modifying MDM name
+type RenameMdm struct {
+	ID      string `json:"id"`
+	NewName string `json:"newName"`
+}
+
 // Link defines struct of Link
 type Link struct {
 	Rel  string `json:"rel"`

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -110,6 +110,12 @@ const (
 	ThreeNodesClusterMode = "ThreeNodes"
 )
 
+// Constants representing MDM role
+const (
+	Manager    = "Manager"
+	TieBreaker = "TieBreaker"
+)
+
 // MdmCluster defines struct for MDM cluster
 type MdmCluster struct {
 	ID              string `json:"id"`

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -104,6 +104,12 @@ type System struct {
 	PerformanceProfile                    string   `json:"perfProfile"`
 }
 
+// Constants representing cluster mode
+const (
+	FiveNodesClusterMode  = "FiveNodes"
+	ThreeNodesClusterMode = "ThreeNodes"
+)
+
 // MdmCluster defines struct for MDM cluster
 type MdmCluster struct {
 	ID              string `json:"id"`

--- a/types/v1/vTreeTypes.go
+++ b/types/v1/vTreeTypes.go
@@ -1,0 +1,29 @@
+package goscaleio
+
+// VTreeDetails defines struct for VTrees
+type VTreeDetails struct {
+	CompressionMethod  string             `json:"compressionMethod"`
+	DataLayout         string             `json:"dataLayout"`
+	ID                 string             `json:"id"`
+	InDeletion         bool               `json:"inDeletion"`
+	Name               string             `json:"name"`
+	RootVolumes        []string           `json:"rootVolumes"`
+	StoragePoolID      string             `json:"storagePoolId"`
+	Links              []*Link            `json:"links"`
+	VtreeMigrationInfo VTreeMigrationInfo `json:"vtreeMigrationInfo"`
+}
+
+// VTreeMigrationInfo defines struct for VTree migration
+type VTreeMigrationInfo struct {
+	DestinationStoragePoolID string `json:"destinationStoragePoolId"`
+	MigrationPauseReason     string `json:"migrationPauseReason"`
+	MigrationQueuePosition   int64  `json:"migrationQueuePosition"`
+	MigrationStatus          string `json:"migrationStatus"`
+	SourceStoragePoolID      string `json:"sourceStoragePoolId"`
+	ThicknessConversionType  string `json:"thicknessConversionType"`
+}
+
+// VTreeQueryBySelectedIdsParam defines struct for specifying Vtree IDs
+type VTreeQueryBySelectedIdsParam struct {
+	IDs []string `json:"ids"`
+}

--- a/vtree.go
+++ b/vtree.go
@@ -1,0 +1,67 @@
+// Copyright © 2019 - 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//      http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package goscaleio
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	types "github.com/dell/goscaleio/types/v1"
+)
+
+// GetVTrees returns vtrees present in the cluster
+func (c *Client) GetVTrees() ([]types.VTreeDetails, error) {
+	defer TimeSpent("GetVTrees", time.Now())
+
+	path := "/api/types/VTree/instances"
+
+	var vTree []types.VTreeDetails
+	err := c.getJSONWithRetry(http.MethodGet, path, nil, &vTree)
+	if err != nil {
+		return nil, err
+	}
+
+	return vTree, nil
+}
+
+// GetVTreeByID returns the VTree details for the given ID
+func (c *Client) GetVTreeByID(id string) (*types.VTreeDetails, error) {
+	defer TimeSpent("GetVTreeByID", time.Now())
+
+	path := fmt.Sprintf("/api/instances/VTree::%v", id)
+
+	var vTree types.VTreeDetails
+	err := c.getJSONWithRetry(http.MethodGet, path, nil, &vTree)
+	if err != nil {
+		return nil, err
+	}
+	return &vTree, nil
+}
+
+// GetVTreeInstances returns the VTree details for the given IDs
+func (c *Client) GetVTreeInstances(ids []string) ([]types.VTreeDetails, error) {
+	defer TimeSpent("GetVTrees", time.Now())
+
+	path := "/api/types/VTree/instances/action/queryBySelectedIds"
+
+	payload := types.VTreeQueryBySelectedIdsParam{
+		IDs: ids,
+	}
+	var vTree []types.VTreeDetails
+	err := c.getJSONWithRetry(http.MethodPost, path, payload, &vTree)
+	if err != nil {
+		return nil, err
+	}
+	return vTree, nil
+}

--- a/vtree.go
+++ b/vtree.go
@@ -65,3 +65,15 @@ func (c *Client) GetVTreeInstances(ids []string) ([]types.VTreeDetails, error) {
 	}
 	return vTree, nil
 }
+
+// GetVTreeByVolumeID returns VTree details based on Volume ID
+func (c *Client) GetVTreeByVolumeID(id string) (*types.VTreeDetails, error) {
+	defer TimeSpent("GetVTreeByVolumeID", time.Now())
+
+	volDetails, err := c.GetVolume("", id, "", "", false)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.GetVTreeByID(volDetails[0].VTreeID)
+}

--- a/vtree_test.go
+++ b/vtree_test.go
@@ -1,0 +1,115 @@
+package goscaleio
+
+import (
+	"errors"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVTrees(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer svr.Close()
+
+	client, err := NewClientWithArgs(svr.URL, "", math.MaxInt64, true, false)
+	client.configConnect.Version = "3.6"
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vTreeDetails, err := client.GetVTrees()
+	assert.Equal(t, len(vTreeDetails), 0)
+	assert.Nil(t, err)
+}
+
+func TestGetVTreeByID(t *testing.T) {
+	type testCase struct {
+		id       string
+		expected error
+	}
+
+	cases := []testCase{
+		{
+			id:       "b21581e400000001",
+			expected: nil,
+		},
+		{
+			id:       "b21581e400000002",
+			expected: errors.New("The VTree was not found"),
+		},
+	}
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	defer svr.Close()
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("", func(ts *testing.T) {
+			client, err := NewClientWithArgs(svr.URL, "", math.MaxInt64, true, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = client.GetVTreeByID(tc.id)
+			if err != nil {
+				if tc.expected == nil {
+					t.Errorf("Getting VTree by ID did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)
+				} else {
+					if err.Error() != tc.expected.Error() {
+						t.Errorf("Getting VTree by ID did not work as expected, \n\tgot: %s \n\twant: %s", err, tc.expected)
+					}
+				}
+			}
+		})
+	}
+
+}
+
+func TestGetVTreeInstances(t *testing.T) {
+	type testCase struct {
+		ids      []string
+		expected error
+	}
+
+	cases := []testCase{
+		{
+			ids:      []string{"b21581e400000001"},
+			expected: nil,
+		},
+		{
+			ids:      []string{"b21581e400000002"},
+			expected: errors.New("Query selected Instances type: VTree - Got no statistics for id b21581e300000002. It doesn't exist."),
+		},
+	}
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	defer svr.Close()
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("", func(ts *testing.T) {
+			client, err := NewClientWithArgs(svr.URL, "", math.MaxInt64, true, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = client.GetVTreeInstances(tc.ids)
+			if err != nil {
+				if tc.expected == nil {
+					t.Errorf("Getting VTree by ID did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)
+				} else {
+					if err.Error() != tc.expected.Error() {
+						t.Errorf("Getting VTree by ID did not work as expected, \n\tgot: %s \n\twant: %s", err, tc.expected)
+					}
+				}
+			}
+		})
+	}
+}

--- a/vtree_test.go
+++ b/vtree_test.go
@@ -84,7 +84,7 @@ func TestGetVTreeInstances(t *testing.T) {
 		},
 		{
 			ids:      []string{"b21581e400000002"},
-			expected: errors.New("Query selected Instances type: VTree - Got no statistics for id b21581e300000002. It doesn't exist."),
+			expected: errors.New("Query selected Instances type: VTree - Got no statistics for id b21581e300000002. It doesn't exist"),
 		},
 	}
 

--- a/vtree_test.go
+++ b/vtree_test.go
@@ -113,3 +113,47 @@ func TestGetVTreeInstances(t *testing.T) {
 		})
 	}
 }
+
+func TestGetVTreeByVolumeID(t *testing.T) {
+	type testCase struct {
+		id       string
+		expected error
+	}
+
+	cases := []testCase{
+		{
+			id:       "3c855e2900000001",
+			expected: nil,
+		},
+		{
+			id:       "b21581e400000002",
+			expected: errors.New("Invalid volume"),
+		},
+	}
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	defer svr.Close()
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("", func(ts *testing.T) {
+			client, err := NewClientWithArgs(svr.URL, "", math.MaxInt64, true, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = client.GetVTreeByVolumeID(tc.id)
+			if err != nil {
+				if tc.expected == nil {
+					t.Errorf("Getting VTree by Volume ID did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)
+				} else {
+					if err.Error() != tc.expected.Error() {
+						t.Errorf("Getting VTree by Volume ID did not work as expected, \n\tgot: %s \n\twant: %s", err, tc.expected)
+					}
+				}
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
# Description
PR is raised to add rename MDM functionality and get VTree details using VTree ID/Volume ID

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/778|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Unit Tests
- [ ] Integration Tests

![image](https://github.com/dell/goscaleio/assets/60608990/d28b5b48-a717-4b35-9a2f-d7b8a598ebac)

![image](https://github.com/dell/goscaleio/assets/60608990/7f65820e-cf45-4d55-aab3-491554c81c01)

![image](https://github.com/dell/goscaleio/assets/60608990/8d82ca2a-103e-4981-a6c7-5a3812e33a37)

![image](https://github.com/dell/goscaleio/assets/60608990/f20fe478-ecb9-4f23-8f30-92b4016ca94b)




