### PR TITLE
remove deprecated io/ioutil package reference from goscaleio

### DIFF
--- a/api.go
+++ b/api.go
@@ -18,7 +18,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"os"
@@ -219,7 +219,7 @@ func (c *Client) getJSONWithRetry(
 }
 
 func extractString(resp *http.Response) (string, error) {
-	bs, err := ioutil.ReadAll(resp.Body)
+	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", errBodyRead
 	}

--- a/api/api_logging.go
+++ b/api/api_logging.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -146,7 +145,7 @@ func drainBody(b io.ReadCloser) (r1, r2 io.ReadCloser, err error) {
 	if err = b.Close(); err != nil {
 		return nil, b, err
 	}
-	return ioutil.NopCloser(&buf), ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+	return io.NopCloser(&buf), io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 }
 
 func dumpRequest(req *http.Request, body bool) ([]byte, error) {

--- a/api_test.go
+++ b/api_test.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -305,7 +304,7 @@ func testBuildError(code int) error {
 
 func testReadAll(t *testing.T, rc io.ReadCloser) []byte {
 	t.Helper()
-	b, err := ioutil.ReadAll(rc)
+	b, err := io.ReadAll(rc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/volume.go
+++ b/volume.go
@@ -15,8 +15,8 @@ package goscaleio
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -161,7 +161,7 @@ func getVolumeMapping(sysID string, volID string) (mappedVolumes []*SdcMappedVol
 	mappedVolumesMap := make(map[string]*SdcMappedVolume)
 
 	diskIDPath := FSDevDirectoryPrefix + "/dev/disk/by-id"
-	files, _ := ioutil.ReadDir(diskIDPath)
+	files, _ := os.ReadDir(diskIDPath)
 	strRegex := fmt.Sprintf(`^emc-vol-%s-%s$`, sysID, volID)
 	r, _ := regexp.Compile(strRegex)
 	for _, f := range files {


### PR DESCRIPTION
# Description
This PR removes the references of deprecated io/ioutil from goscalio 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/916 |
| https://github.com/dell/csm/issues/885 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests passed with 100%
- [x] Manually invoked the functions which has changes and there is no regression identified
- [x] Run Cert-csi after installing the driver with the changes and the cert-csi passed with 100% 
```
[2023-08-14 06:37:42]  INFO Avg time of a run:   55.59s
[2023-08-14 06:37:42]  INFO Avg time of a del:   24.97s
[2023-08-14 06:37:42]  INFO Avg time of all:     83.58s
[2023-08-14 06:37:42]  INFO During this run 100.0% of suites succeeded
```
