### PR TITLE
Added sdcIPs parameter

### DIFF
--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -452,6 +452,7 @@ type Sdc struct {
 	SystemID           string  `json:"systemId"`
 	SdcApproved        bool    `json:"sdcApproved"`
 	SdcIP              string  `json:"SdcIp"`
+	SdcIPs             []string  `json:"SdcIps"`
 	OnVMWare           bool    `json:"onVmWare"`
 	SdcGUID            string  `json:"sdcGuid"`
 	MdmConnectionState string  `json:"mdmConnectionState"`


### PR DESCRIPTION
# Description
Added sdcIPs parameter in the Sdc struct such that when worker host have multiple ip's, all of them can be added to NFS export when ControllerPublishVolume call will happen.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1011 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran make unit-test
![image](https://github.com/dell/goscaleio/assets/109594002/c59e20b0-f0b1-49e5-97b2-4c038d1a0050)

- [x] Installed the driver, sdcIPs parameter was getting populated and used by the ControllerPublishVolume call. 

