### PR TITLE
Add GetStoragePoolVolumes api to get all volumes connected to given s…

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -284,3 +284,18 @@ func (c *Client) GetSnapshotPolicy(
 	sps = append(sps, sp)
 	return sps, nil
 }
+
+// GetStoragePoolVolumes returns list of volumes connected to storage pool Storagepool by ID
+func (c *Client) GetStoragePoolVolumes(id string) ([]*types.Volume, error) {
+	defer TimeSpent("GetStoragePoolByID", time.Now())
+
+	path := fmt.Sprintf("/api/instances/StoragePool::%s/relationships/Volume", id)
+	var storagepoolVolumes []*types.Volume
+	err := c.getJSONWithRetry(
+		http.MethodGet, path, nil, &storagepoolVolumes)
+	if err != nil {
+		return nil, err
+	}
+
+	return storagepoolVolumes, err
+}

--- a/inttests/volume_test.go
+++ b/inttests/volume_test.go
@@ -779,3 +779,29 @@ func TestSetCompressionMethod(t *testing.T) {
 	err = deleteVolume(t, volID)
 	assert.Nil(t, err)
 }
+
+func TestGetStoragePoolVolumes(t *testing.T) {
+	name := fmt.Sprintf("%s-%s", testPrefix, "instanceCreated")
+
+	poolName := getStoragePoolName(t)
+	assert.NotNil(t, poolName)
+
+	pool := getStoragePool(t)
+	size := fmt.Sprintf("%d", defaultVolumeSize)
+
+	volParams := siotypes.VolumeParam{
+		VolumeSizeInKb: size,
+		VolumeType:     "ThinProvisioned",
+		Name:           name,
+	}
+
+	volResp, err := C.CreateVolume(&volParams, poolName, "")
+	assert.Nil(t, err)
+	assert.NotNil(t, volResp)
+
+	volumes, err := C.GetStoragePoolVolumes(pool.StoragePool.ID)
+	assert.Nil(t, err)
+	assert.NotNil(t, volumes)
+
+	deleteVolume(t, volResp.ID)
+}


### PR DESCRIPTION
# Description
Add GetStoragePoolVolumes api to get all volumes connected to given storagepool


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #https://github.com/dell/csm/issues/1221 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] [root@alik-10-247-98-112 inttests]# go test -v -run  TestGetStoragePoolVolumes
=== RUN   TestGetStoragePoolVolumes
--- PASS: TestGetStoragePoolVolumes (0.26s)
PASS
ok      github.com/dell/goscaleio/inttests      0.346s

- [x] Run manual test to get list of volumes belong to storagepool. Also used in CSM Authorization

