### PR TITLE
Using only secured cipher suites

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -117,6 +117,17 @@ type client struct {
 	debug    bool
 }
 
+// GetSecuredCipherSuites returns a slice of secured cipher suites.
+// It iterates over the tls.CipherSuites() and appends the ID of each cipher su                                                                             ite to the suites slice.
+// The function returns the suites slice.
+func GetSecuredCipherSuites() (suites []uint16) {
+	securedSuite := tls.CipherSuites()
+	for _, v := range securedSuite {
+		suites = append(suites, v.ID)
+	}
+	return suites
+}
+
 // ClientOptions are options for the API client.
 type ClientOptions struct {
 	// Insecure is a flag that indicates whether or not to supress SSL errors.
@@ -160,6 +171,7 @@ func New(
 			TLSClientConfig: &tls.Config{
 				// #nosec G402
 				InsecureSkipVerify: true, // #nosec G402
+				CipherSuites:       GetSecuredCipherSuites(),
 			},
 		}
 	}
@@ -175,6 +187,7 @@ func New(
 				RootCAs: pool,
 				// #nosec G402
 				InsecureSkipVerify: opts.Insecure,
+				CipherSuites:       GetSecuredCipherSuites(),
 			},
 		}
 	}

--- a/deploy.go
+++ b/deploy.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dell/goscaleio/api"
 	types "github.com/dell/goscaleio/types/v1"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -71,6 +72,7 @@ func NewGateway(host string, username, password string, insecure, useCerts bool)
 			TLSClientConfig: &tls.Config{
 				// #nosec G402
 				InsecureSkipVerify: true,
+				CipherSuites:       api.GetSecuredCipherSuites(),
 			},
 		}
 	}
@@ -86,6 +88,7 @@ func NewGateway(host string, username, password string, insecure, useCerts bool)
 				RootCAs: pool,
 				// #nosec G402
 				InsecureSkipVerify: insecure,
+				CipherSuites:       api.GetSecuredCipherSuites(),
 			},
 		}
 	}


### PR DESCRIPTION
# Description
A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
Using only secured cipher suites

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1221|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested with various PowerFlex builds, driver pods running successfully in all scenarios.
With PowerFlex 4.5, PowerFlex 4.0 & PowerFlex 3.6.x
![image](https://github.com/dell/goscaleio/assets/109594002/e91908a3-5ebf-4cc8-a69e-ee79a5d7362c)


