### PR TITLE
Get, Pause and Resume Specific Replication Pair

### DIFF
--- a/inttests/replication_test.go
+++ b/inttests/replication_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2020-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  * limitations under the License.
  *
  */
-
 package inttests
 
 import (
@@ -325,6 +324,34 @@ func TestQueryReplicationPairs(t *testing.T) {
 		replicationPair.ReplicaitonPair = pair
 		rep.pair = replicationPair
 	}
+}
+
+// Query Specific Replication Pair
+func TestQueryReplicationPair(t *testing.T) {
+	if C2 == nil {
+		t.Skip("no client connection to replication target system")
+	}
+
+	pair, err := C.GetReplicationPair(rep.pair.ReplicaitonPair.ID)
+	assert.Nil(t, err)
+	assert.NotNil(t, pair)
+}
+
+// Pause and Resume Replication Pair
+func TestPauseAndResumeReplicationPair(t *testing.T) {
+	if C2 == nil {
+		t.Skip("no client connection to replication target system")
+	}
+
+	// Pause
+	pairP, err := C.PausePairInitialCopy(rep.pair.ReplicaitonPair.ID)
+	assert.Nil(t, err)
+	assert.NotNil(t, pairP)
+
+	// Resume
+	pairR, err := C.ResumePairInitialCopy(rep.pair.ReplicaitonPair.ID)
+	assert.Nil(t, err)
+	assert.NotNil(t, pairR)
 }
 
 // Query Replication Pair Statistics

--- a/replication.go
+++ b/replication.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright © 2020-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package goscaleio
 
 import (
@@ -210,6 +227,39 @@ func (c *Client) GetAllReplicationPairs() ([]*types.ReplicationPair, error) {
 	var pairs []*types.ReplicationPair
 	err := c.getJSONWithRetry(http.MethodGet, path, nil, &pairs)
 	return pairs, err
+}
+
+// GetReplicationPair returns a specific replication pair on the system.
+func (c *Client) GetReplicationPair(id string) (*types.ReplicationPair, error) {
+	defer TimeSpent("GetReplicationPair", time.Now())
+
+	path := "/api/instances/ReplicationPair::" + id
+
+	var pair *types.ReplicationPair
+	err := c.getJSONWithRetry(http.MethodGet, path, nil, &pair)
+	return pair, err
+}
+
+// PausePairInitialCopy pauses the initial copy of the replication pair.
+func (c *Client) PausePairInitialCopy(id string) (*types.ReplicationPair, error) {
+	defer TimeSpent("PausePairInitialCopy", time.Now())
+
+	path := "/api/instances/ReplicationPair::" + id + "/action/pausePairInitialCopy"
+
+	var pair *types.ReplicationPair
+	err := c.getJSONWithRetry(http.MethodPost, path, types.EmptyPayload{}, &pair)
+	return pair, err
+}
+
+// ResumePairInitialCopy resumes the initial copy of the replication pair.
+func (c *Client) ResumePairInitialCopy(id string) (*types.ReplicationPair, error) {
+	defer TimeSpent("ResumePairInitialCopy", time.Now())
+
+	path := "/api/instances/ReplicationPair::" + id + "/action/resumePairInitialCopy"
+
+	var pair *types.ReplicationPair
+	err := c.getJSONWithRetry(http.MethodPost, path, types.EmptyPayload{}, &pair)
+	return pair, err
 }
 
 // GetReplicationPairs returns a list of replication pairs associated to the rcg.


### PR DESCRIPTION
# Description
- Add method to get a specific Replication Pair
- Add method to pause initial Replication Pair
- Add method to resume initial Replication Pair
 
## Test output
![image](https://github.com/user-attachments/assets/62326082-15c3-48f8-858b-5270c83ad9bd)
![image](https://github.com/user-attachments/assets/c4093033-d026-45c0-a92f-86fb67e838a4)


# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit Test

