### PR TITLE
NVMe host name could be null

### DIFF
--- a/nvme_host.go
+++ b/nvme_host.go
@@ -59,7 +59,7 @@ func (s *System) GetAllNvmeHosts() ([]types.NvmeHost, error) {
 }
 
 // GetNvmeHostByID returns an NVMe host searched by id
-func (s *System) GetNvmeHostByID(id string) (*NvmeHost, error) {
+func (s *System) GetNvmeHostByID(id string) (*types.NvmeHost, error) {
 	defer TimeSpent("GetNvmeHostByID", time.Now())
 
 	path := fmt.Sprintf("api/instances/Sdc::%v", id)
@@ -71,7 +71,7 @@ func (s *System) GetNvmeHostByID(id string) (*NvmeHost, error) {
 		return nil, err
 	}
 
-	return NewNvmeHost(s.client, &nvmeHost), nil
+	return &nvmeHost, nil
 }
 
 // CreateNvmeHost creates a new NVMe host

--- a/nvme_host_test.go
+++ b/nvme_host_test.go
@@ -148,7 +148,7 @@ func Test_GetAllNvmeHosts(t *testing.T) {
 }
 
 func Test_GetNvmeHostByID(t *testing.T) {
-	type checkFn func(*testing.T, *NvmeHost, error)
+	type checkFn func(*testing.T, *types.NvmeHost, error)
 	check := func(fns ...checkFn) []checkFn { return fns }
 
 	responseJSON := `{
@@ -201,19 +201,19 @@ func Test_GetNvmeHostByID(t *testing.T) {
     ]
 }`
 
-	hasNoError := func(t *testing.T, _ *NvmeHost, err error) {
+	hasNoError := func(t *testing.T, _ *types.NvmeHost, err error) {
 		if err != nil {
 			t.Fatalf("expected no error")
 		}
 	}
 
-	checkName := func(name string) func(t *testing.T, host *NvmeHost, err error) {
-		return func(t *testing.T, host *NvmeHost, _ error) {
-			assert.Equal(t, host.NvmeHost.Name, name)
+	checkName := func(name string) func(t *testing.T, host *types.NvmeHost, err error) {
+		return func(t *testing.T, host *types.NvmeHost, _ error) {
+			assert.Equal(t, host.Name, name)
 		}
 	}
 
-	hasError := func(t *testing.T, _ *NvmeHost, err error) {
+	hasError := func(t *testing.T, _ *types.NvmeHost, err error) {
 		if err == nil {
 			t.Fatalf("expected error")
 		}

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -2054,7 +2054,7 @@ type ChangeNvmeHostMaxNumSysPortsParam struct {
 
 // NvmeHostParam defines struct for creating an NVMe host
 type NvmeHostParam struct {
-	Name           string    `json:"name"`
+	Name           string    `json:"name,omitempty"`
 	Nqn            string    `json:"nqn"`
 	MaxNumPaths    IntString `json:"maxNumPaths,omitempty"`
 	MaxNumSysPorts IntString `json:"maxNumSysPorts,omitempty"`


### PR DESCRIPTION
# Description
When creating an NVMe host without specifying a name, the PowerFlex manager uses HostType:ID as the display name, and we follow the same behavior.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] AT

![image](https://github.com/user-attachments/assets/e21b4b86-6b16-40b4-825a-8daaab5d7b5d)
![image](https://github.com/user-attachments/assets/4015e12b-be2d-4672-a6d7-d863590b3770)
![image](https://github.com/user-attachments/assets/a73883ba-10b4-4169-b077-e6d9a3c322c0)

