### PR TITLE
RCG Snapshot Force Error

### DIFF
--- a/inttests/replication_test.go
+++ b/inttests/replication_test.go
@@ -498,7 +498,7 @@ func TestCreateReplicationConsistencyGroupSnapshot(t *testing.T) {
 		t.Skip("no client connection to replication target system")
 	}
 
-	resp, err := rep.rcg.CreateReplicationConsistencyGroupSnapshot(false)
+	resp, err := rep.rcg.CreateReplicationConsistencyGroupSnapshot()
 	assert.Nil(t, err)
 
 	t.Logf("Consistency Group Snapshot ID: %s", resp.SnapshotGroupID)

--- a/replication.go
+++ b/replication.go
@@ -400,17 +400,14 @@ func (rcg *ReplicationConsistencyGroup) GetReplicationPairs() ([]*types.Replicat
 }
 
 // CreateReplicationConsistencyGroupSnapshot creates a snapshot of the ReplicationConsistencyGroup on the target array.
-func (rcg *ReplicationConsistencyGroup) CreateReplicationConsistencyGroupSnapshot(force bool) (*types.CreateReplicationConsistencyGroupSnapshotResp, error) {
+func (rcg *ReplicationConsistencyGroup) CreateReplicationConsistencyGroupSnapshot() (*types.CreateReplicationConsistencyGroupSnapshotResp, error) {
 	defer TimeSpent("GetReplicationPairs", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/createReplicationConsistencyGroupSnapshots"
-	param := &types.CreateReplicationConsistencyGroupSnapshot{
-		Force: force,
-	}
 
 	resp := &types.CreateReplicationConsistencyGroupSnapshotResp{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, resp)
+	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, types.EmptyPayload{}, resp)
 	return resp, err
 }
 


### PR DESCRIPTION
# Description
- When doing a Create RCG Snapshot, there is no force value in the body of the request. If force is included on  POST request it ends in an error and does not create the snapshot.

## Error if force body is sent
![image](https://github.com/user-attachments/assets/8afb5bd5-1c6f-4f56-bca9-dd4821dde2d6)


# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit Test 
## Test output 
![image](https://github.com/user-attachments/assets/1fec8d28-e409-42a9-aed7-4466f6fdc9f3)


