### PR TITLE
WIP: Add Context to goscaleio calls instead of using the context background

### DIFF
--- a/api.go
+++ b/api.go
@@ -88,7 +88,7 @@ func (c *Client) GetVersion() (string, error) {
 		return "", errNilReponse
 	case resp.StatusCode == http.StatusUnauthorized:
 		// Authenticate then try again
-		if _, err = c.Authenticate(c.configConnect); err != nil {
+		if _, err = c.Authenticate(context.Background(), c.configConnect); err != nil {
 			return "", err
 		}
 		resp, err = c.api.DoAndGetResponseBody(
@@ -134,7 +134,7 @@ func updateHeaders(version string) {
 }
 
 // Authenticate controls authentication to client
-func (c *Client) Authenticate(configConnect *ConfigConnect) (Cluster, error) {
+func (c *Client) Authenticate(ctx context.Context, configConnect *ConfigConnect) (Cluster, error) {
 	configConnect.Version = c.configConnect.Version
 	c.configConnect = configConnect
 
@@ -145,7 +145,7 @@ func (c *Client) Authenticate(configConnect *ConfigConnect) (Cluster, error) {
 		configConnect.Username, configConnect.Password)
 
 	resp, err := c.api.DoAndGetResponseBody(
-		context.Background(), http.MethodGet, "api/login", headers, nil, c.configConnect.Version)
+		ctx, http.MethodGet, "api/login", headers, nil, c.configConnect.Version)
 	if err != nil {
 		doLog(log.WithError(err).Error, "")
 		return Cluster{}, err
@@ -208,7 +208,7 @@ func (c *Client) getJSONWithRetry(
 		if e.HTTPStatusCode == 401 {
 			doLog(log.Info, "Need to re-auth")
 			// Authenticate then try again
-			if _, err := c.Authenticate(c.configConnect); err != nil {
+			if _, err := c.Authenticate(context.Background(), c.configConnect); err != nil {
 				return fmt.Errorf("Error Authenticating: %s", err)
 			}
 			return c.api.DoWithHeaders(
@@ -284,7 +284,7 @@ func (c *Client) getStringWithRetry(
 		if retry {
 			doLog(log.Info, "need to re-auth")
 			// Authenticate then try again
-			if _, err = c.Authenticate(c.configConnect); err != nil {
+			if _, err = c.Authenticate(context.Background(), c.configConnect); err != nil {
 				return "", fmt.Errorf("Error Authenticating: %s", err)
 			}
 			resp, err = c.api.DoAndGetResponseBody(

--- a/api_test.go
+++ b/api_test.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -35,7 +36,7 @@ func setupClient(t *testing.T, hostAddr string) *Client {
 		t.Fatal(err)
 	}
 	// test ok
-	_, err = client.Authenticate(&ConfigConnect{
+	_, err = client.Authenticate(context.Background(), &ConfigConnect{
 		Username: "ScaleIOUser",
 		Password: "password",
 		Version:  "2.0",
@@ -123,7 +124,7 @@ func TestClientVersion(t *testing.T) {
 	}
 
 	// Test successful authentication
-	_, err = client.Authenticate(&ConfigConnect{
+	_, err = client.Authenticate(context.Background(), &ConfigConnect{
 		Username: "ScaleIOUser",
 		Password: "password",
 		Endpoint: "",
@@ -193,7 +194,7 @@ func TestClientLogin(t *testing.T) {
 		t.Fatal(err)
 	}
 	// test ok
-	_, err = client.Authenticate(&ConfigConnect{
+	_, err = client.Authenticate(context.Background(), &ConfigConnect{
 		Username: "ScaleIOUser",
 		Password: "password",
 		Endpoint: "",
@@ -207,7 +208,7 @@ func TestClientLogin(t *testing.T) {
 	}
 
 	// test bad login
-	_, err = client.Authenticate(&ConfigConnect{
+	_, err = client.Authenticate(context.Background(), &ConfigConnect{
 		Username: "ScaleIOUser",
 		Password: "badPassWord",
 		Endpoint: "",

--- a/api_test.go
+++ b/api_test.go
@@ -135,7 +135,7 @@ func TestClientVersion(t *testing.T) {
 	}
 
 	// Test for version retrieval
-	ver, err := client.GetVersion()
+	ver, err := client.GetVersion(context.Background())
 	if err != nil {
 		// Check if the error is due to unauthorized access
 		if strings.Contains(err.Error(), "Unauthorized") {
@@ -320,7 +320,7 @@ func Test_getJSONWithRetry(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c.getJSONWithRetry(http.MethodPost, "/testing", wantBody, nil)
+		c.getJSONWithRetry(context.Background(), http.MethodPost, "/testing", wantBody, nil)
 
 		// Assert the call order was as expected.
 		wantPaths := []string{"POST /testing", "GET /api/login", "POST /testing"}

--- a/compatibility_management.go
+++ b/compatibility_management.go
@@ -13,17 +13,17 @@
 package goscaleio
 
 import (
+	"context"
 	"net/http"
 
 	types "github.com/dell/goscaleio/types/v1"
 )
 
 // GetCompatibilityManagement Gets Compatibility Management
-func (s *System) GetCompatibilityManagement() (*types.CompatibilityManagement, error) {
+func (s *System) GetCompatibilityManagement(ctx context.Context) (*types.CompatibilityManagement, error) {
 	path := "/api/v1/Compatibility"
 	var compatibilityManagement types.CompatibilityManagement
-	err := s.client.getJSONWithRetry(
-		http.MethodGet, path, nil, &compatibilityManagement)
+	err := s.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &compatibilityManagement)
 	if err != nil {
 		return nil, err
 	}
@@ -32,11 +32,10 @@ func (s *System) GetCompatibilityManagement() (*types.CompatibilityManagement, e
 }
 
 // SetCompatibilityManagement Sets Compatibility Management
-func (s *System) SetCompatibilityManagement(compatibilityManagement *types.CompatibilityManagementPost) (*types.CompatibilityManagement, error) {
+func (s *System) SetCompatibilityManagement(ctx context.Context, compatibilityManagement *types.CompatibilityManagementPost) (*types.CompatibilityManagement, error) {
 	path := "/api/v1/Compatibility"
 	resp := types.CompatibilityManagement{}
-	err := s.client.getJSONWithRetry(
-		http.MethodPost, path, compatibilityManagement, &resp)
+	err := s.client.getJSONWithRetry(ctx, http.MethodPost, path, compatibilityManagement, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/device.go
+++ b/device.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -45,11 +46,11 @@ func NewDeviceEx(client *Client, device *types.Device) *Device {
 }
 
 // AttachDevice attaches a device
-func (sp *StoragePool) AttachDevice(deviceParam *types.DeviceParam) (string, error) {
+func (sp *StoragePool) AttachDevice(ctx context.Context, deviceParam *types.DeviceParam) (string, error) {
 	defer TimeSpent("AttachDevice", time.Now())
 	deviceParam.StoragePoolID = sp.StoragePool.ID
 	dev := types.DeviceResp{}
-	err := sp.client.getJSONWithRetry(
+	err := sp.client.getJSONWithRetry(ctx,
 		http.MethodPost, "/api/types/Device/instances",
 		deviceParam, &dev)
 	if err != nil {
@@ -60,7 +61,7 @@ func (sp *StoragePool) AttachDevice(deviceParam *types.DeviceParam) (string, err
 }
 
 // GetDevice returns a device based on Storage Pool ID
-func (sp *StoragePool) GetDevice() ([]types.Device, error) {
+func (sp *StoragePool) GetDevice(ctx context.Context) ([]types.Device, error) {
 	defer TimeSpent("GetDevice", time.Now())
 
 	path := fmt.Sprintf(
@@ -68,7 +69,7 @@ func (sp *StoragePool) GetDevice() ([]types.Device, error) {
 		sp.StoragePool.ID)
 
 	var devices []types.Device
-	err := sp.client.getJSONWithRetry(
+	err := sp.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &devices)
 	if err != nil {
 		return nil, err
@@ -78,12 +79,12 @@ func (sp *StoragePool) GetDevice() ([]types.Device, error) {
 }
 
 // FindDevice returns a Device
-func (sp *StoragePool) FindDevice(
+func (sp *StoragePool) FindDevice(ctx context.Context,
 	field, value string,
 ) (*types.Device, error) {
 	defer TimeSpent("FindDevice", time.Now())
 
-	devices, err := sp.GetDevice()
+	devices, err := sp.GetDevice(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +101,7 @@ func (sp *StoragePool) FindDevice(
 }
 
 // GetDevice returns a devices based on SDS ID
-func (sds *Sds) GetDevice() ([]types.Device, error) {
+func (sds *Sds) GetDevice(ctx context.Context) ([]types.Device, error) {
 	defer TimeSpent("GetSDSDevice", time.Now())
 
 	path := fmt.Sprintf(
@@ -108,7 +109,7 @@ func (sds *Sds) GetDevice() ([]types.Device, error) {
 		sds.Sds.ID)
 
 	var devices []types.Device
-	err := sds.client.getJSONWithRetry(http.MethodGet, path, nil, &devices)
+	err := sds.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &devices)
 	if err != nil {
 		return nil, err
 	}
@@ -117,12 +118,12 @@ func (sds *Sds) GetDevice() ([]types.Device, error) {
 }
 
 // FindDevice returns a Device
-func (sds *Sds) FindDevice(
+func (sds *Sds) FindDevice(ctx context.Context,
 	field, value string,
 ) (*types.Device, error) {
 	defer TimeSpent("FindDevice", time.Now())
 
-	devices, err := sds.GetDevice()
+	devices, err := sds.GetDevice(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -139,13 +140,13 @@ func (sds *Sds) FindDevice(
 }
 
 // GetAllDevice returns all device in the system
-func (s *System) GetAllDevice() ([]types.Device, error) {
+func (s *System) GetAllDevice(ctx context.Context) ([]types.Device, error) {
 	defer TimeSpent("GetAllDevice", time.Now())
 
 	path := "/api/types/Device/instances"
 
 	var deviceResult []types.Device
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &deviceResult)
 	if err != nil {
 		return nil, err
@@ -155,12 +156,10 @@ func (s *System) GetAllDevice() ([]types.Device, error) {
 }
 
 // GetDeviceByField returns a Device list filter by the field
-func (s *System) GetDeviceByField(
-	field, value string,
-) ([]types.Device, error) {
+func (s *System) GetDeviceByField(ctx context.Context, field, value string) ([]types.Device, error) {
 	defer TimeSpent("GetDeviceByField", time.Now())
 
-	devices, err := s.GetAllDevice()
+	devices, err := s.GetAllDevice(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +179,7 @@ func (s *System) GetDeviceByField(
 }
 
 // GetDevice returns a device using Device ID
-func (s *System) GetDevice(id string) (*types.Device, error) {
+func (s *System) GetDevice(ctx context.Context, id string) (*types.Device, error) {
 	defer TimeSpent("GetDevice", time.Now())
 
 	path := fmt.Sprintf(
@@ -188,8 +187,7 @@ func (s *System) GetDevice(id string) (*types.Device, error) {
 		id)
 
 	var deviceResult types.Device
-	err := s.client.getJSONWithRetry(
-		http.MethodGet, path, nil, &deviceResult)
+	err := s.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &deviceResult)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +196,7 @@ func (s *System) GetDevice(id string) (*types.Device, error) {
 }
 
 // SetDeviceName modifies device name
-func (sp *StoragePool) SetDeviceName(id, name string) error {
+func (sp *StoragePool) SetDeviceName(ctx context.Context, id, name string) error {
 	defer TimeSpent("SetDeviceName", time.Now())
 
 	deviceParam := &types.SetDeviceName{
@@ -206,8 +204,7 @@ func (sp *StoragePool) SetDeviceName(id, name string) error {
 	}
 	path := fmt.Sprintf("/api/instances/Device::%v/action/setDeviceName", id)
 
-	err := sp.client.getJSONWithRetry(
-		http.MethodPost, path, deviceParam, nil)
+	err := sp.client.getJSONWithRetry(ctx, http.MethodPost, path, deviceParam, nil)
 	if err != nil {
 		return err
 	}
@@ -215,7 +212,7 @@ func (sp *StoragePool) SetDeviceName(id, name string) error {
 }
 
 // SetDeviceMediaType modifies device media type
-func (sp *StoragePool) SetDeviceMediaType(id, mediaType string) error {
+func (sp *StoragePool) SetDeviceMediaType(ctx context.Context, id, mediaType string) error {
 	defer TimeSpent("SetDeviceMediaType", time.Now())
 
 	deviceParam := &types.SetDeviceMediaType{
@@ -223,8 +220,7 @@ func (sp *StoragePool) SetDeviceMediaType(id, mediaType string) error {
 	}
 	path := fmt.Sprintf("/api/instances/Device::%v/action/setMediaType", id)
 
-	err := sp.client.getJSONWithRetry(
-		http.MethodPost, path, deviceParam, nil)
+	err := sp.client.getJSONWithRetry(ctx, http.MethodPost, path, deviceParam, nil)
 	if err != nil {
 		return err
 	}
@@ -232,7 +228,7 @@ func (sp *StoragePool) SetDeviceMediaType(id, mediaType string) error {
 }
 
 // SetDeviceExternalAccelerationType modifies device external acceleration type
-func (sp *StoragePool) SetDeviceExternalAccelerationType(id, externalAccelerationType string) error {
+func (sp *StoragePool) SetDeviceExternalAccelerationType(ctx context.Context, id, externalAccelerationType string) error {
 	defer TimeSpent("SetDeviceExternalAccelerationType", time.Now())
 
 	deviceParam := &types.SetDeviceExternalAccelerationType{
@@ -240,8 +236,7 @@ func (sp *StoragePool) SetDeviceExternalAccelerationType(id, externalAcceleratio
 	}
 	path := fmt.Sprintf("/api/instances/Device::%v/action/setExternalAccelerationType", id)
 
-	err := sp.client.getJSONWithRetry(
-		http.MethodPost, path, deviceParam, nil)
+	err := sp.client.getJSONWithRetry(ctx, http.MethodPost, path, deviceParam, nil)
 	if err != nil {
 		return err
 	}
@@ -249,7 +244,7 @@ func (sp *StoragePool) SetDeviceExternalAccelerationType(id, externalAcceleratio
 }
 
 // SetDeviceCapacityLimit modifies device capacity limit
-func (sp *StoragePool) SetDeviceCapacityLimit(id, capacityLimitInGB string) error {
+func (sp *StoragePool) SetDeviceCapacityLimit(ctx context.Context, id, capacityLimitInGB string) error {
 	defer TimeSpent("SetDeviceExternalAccelerationType", time.Now())
 
 	deviceParam := &types.SetDeviceCapacityLimit{
@@ -257,8 +252,7 @@ func (sp *StoragePool) SetDeviceCapacityLimit(id, capacityLimitInGB string) erro
 	}
 	path := fmt.Sprintf("/api/instances/Device::%v/action/setDeviceCapacityLimit", id)
 
-	err := sp.client.getJSONWithRetry(
-		http.MethodPost, path, deviceParam, nil)
+	err := sp.client.getJSONWithRetry(ctx, http.MethodPost, path, deviceParam, nil)
 	if err != nil {
 		return err
 	}
@@ -266,14 +260,13 @@ func (sp *StoragePool) SetDeviceCapacityLimit(id, capacityLimitInGB string) erro
 }
 
 // UpdateDeviceOriginalPathways modifies device path if changed during server restart
-func (sp *StoragePool) UpdateDeviceOriginalPathways(id string) error {
+func (sp *StoragePool) UpdateDeviceOriginalPathways(ctx context.Context, id string) error {
 	defer TimeSpent("UpdateDeviceOriginalPathways", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Device::%v/action/updateDeviceOriginalPathname", id)
 	deviceParam := &types.EmptyPayload{}
 
-	err := sp.client.getJSONWithRetry(
-		http.MethodPost, path, deviceParam, nil)
+	err := sp.client.getJSONWithRetry(ctx, http.MethodPost, path, deviceParam, nil)
 	if err != nil {
 		return err
 	}
@@ -281,13 +274,12 @@ func (sp *StoragePool) UpdateDeviceOriginalPathways(id string) error {
 }
 
 // RemoveDevice removes device from storage pool
-func (sp *StoragePool) RemoveDevice(id string) error {
+func (sp *StoragePool) RemoveDevice(ctx context.Context, id string) error {
 	defer TimeSpent("RemoveDevice", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Device::%v/action/removeDevice", id)
 
-	err := sp.client.getJSONWithRetry(
-		http.MethodPost, path, nil, nil)
+	err := sp.client.getJSONWithRetry(ctx, http.MethodPost, path, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/fault_set.go
+++ b/fault_set.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -22,12 +23,11 @@ import (
 )
 
 // CreateFaultSet creates a fault set
-func (pd *ProtectionDomain) CreateFaultSet(fs *types.FaultSetParam) (string, error) {
+func (pd *ProtectionDomain) CreateFaultSet(ctx context.Context, fs *types.FaultSetParam) (string, error) {
 	path := fmt.Sprintf("/api/types/FaultSet/instances")
 	fs.ProtectionDomainID = pd.ProtectionDomain.ID
 	fsResp := types.FaultSetResp{}
-	err := pd.client.getJSONWithRetry(
-		http.MethodPost, path, fs, &fsResp)
+	err := pd.client.getJSONWithRetry(ctx, http.MethodPost, path, fs, &fsResp)
 	if err != nil {
 		return "", err
 	}
@@ -35,11 +35,10 @@ func (pd *ProtectionDomain) CreateFaultSet(fs *types.FaultSetParam) (string, err
 }
 
 // DeleteFaultSet will delete a fault set
-func (pd *ProtectionDomain) DeleteFaultSet(id string) error {
+func (pd *ProtectionDomain) DeleteFaultSet(ctx context.Context, id string) error {
 	path := fmt.Sprintf("/api/instances/FaultSet::%v/action/removeFaultSet", id)
 	fsParam := &types.EmptyPayload{}
-	err := pd.client.getJSONWithRetry(
-		http.MethodPost, path, fsParam, nil)
+	err := pd.client.getJSONWithRetry(ctx, http.MethodPost, path, fsParam, nil)
 	if err != nil {
 		return err
 	}
@@ -47,13 +46,12 @@ func (pd *ProtectionDomain) DeleteFaultSet(id string) error {
 }
 
 // ModifyFaultSetName will modify the name of the fault set
-func (pd *ProtectionDomain) ModifyFaultSetName(id, name string) error {
+func (pd *ProtectionDomain) ModifyFaultSetName(ctx context.Context, id, name string) error {
 	fs := &types.FaultSetRename{}
 	fs.NewName = name
 	path := fmt.Sprintf("/api/instances/FaultSet::%v/action/setFaultSetName", id)
 
-	err := pd.client.getJSONWithRetry(
-		http.MethodPost, path, fs, nil)
+	err := pd.client.getJSONWithRetry(ctx, http.MethodPost, path, fs, nil)
 	if err != nil {
 		return err
 	}
@@ -61,13 +59,12 @@ func (pd *ProtectionDomain) ModifyFaultSetName(id, name string) error {
 }
 
 // ModifyFaultSetPerfProfile will modify the performance profile of the fault set
-func (pd *ProtectionDomain) ModifyFaultSetPerfProfile(id, perfProfile string) error {
+func (pd *ProtectionDomain) ModifyFaultSetPerfProfile(ctx context.Context, id, perfProfile string) error {
 	pp := &types.ChangeSdcPerfProfile{}
 	pp.PerfProfile = perfProfile
 	path := fmt.Sprintf("/api/instances/FaultSet::%v/action/setSdsPerformanceParameters", id)
 
-	err := pd.client.getJSONWithRetry(
-		http.MethodPost, path, pp, nil)
+	err := pd.client.getJSONWithRetry(ctx, http.MethodPost, path, pp, nil)
 	if err != nil {
 		return err
 	}
@@ -75,12 +72,11 @@ func (pd *ProtectionDomain) ModifyFaultSetPerfProfile(id, perfProfile string) er
 }
 
 // GetFaultSetByID will read the fault set using the ID.
-func (s *System) GetFaultSetByID(id string) (*types.FaultSet, error) {
+func (s *System) GetFaultSetByID(ctx context.Context, id string) (*types.FaultSet, error) {
 	fs := &types.FaultSet{}
 	path := fmt.Sprintf("/api/instances/FaultSet::%v", id)
 
-	err := s.client.getJSONWithRetry(
-		http.MethodGet, path, nil, fs)
+	err := s.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, fs)
 	if err != nil {
 		return nil, err
 	}
@@ -88,13 +84,12 @@ func (s *System) GetFaultSetByID(id string) (*types.FaultSet, error) {
 }
 
 // GetAllFaultSets returns all fault sets on the system
-func (s *System) GetAllFaultSets() ([]types.FaultSet, error) {
+func (s *System) GetAllFaultSets(ctx context.Context) ([]types.FaultSet, error) {
 	defer TimeSpent("FaultSet", time.Now())
 	path := "/api/types/FaultSet/instances"
 
 	var faultsets []types.FaultSet
-	err := s.client.getJSONWithRetry(
-		http.MethodGet, path, nil, &faultsets)
+	err := s.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &faultsets)
 	if err != nil {
 		return nil, err
 	}
@@ -103,13 +98,12 @@ func (s *System) GetAllFaultSets() ([]types.FaultSet, error) {
 }
 
 // GetAllSDSByFaultSetID returns SDS details associated with fault set
-func (s *System) GetAllSDSByFaultSetID(faultsetid string) ([]types.Sds, error) {
+func (s *System) GetAllSDSByFaultSetID(ctx context.Context, faultsetid string) ([]types.Sds, error) {
 	defer TimeSpent("FaultSet", time.Now())
 	path := fmt.Sprintf("/api/instances/FaultSet::%v/relationships/Sds", faultsetid)
 
 	var faultsets []types.Sds
-	err := s.client.getJSONWithRetry(
-		http.MethodGet, path, nil, &faultsets)
+	err := s.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &faultsets)
 	if err != nil {
 		return nil, err
 	}
@@ -118,8 +112,8 @@ func (s *System) GetAllSDSByFaultSetID(faultsetid string) ([]types.Sds, error) {
 }
 
 // GetFaultSetByName will read the fault set using the name
-func (s *System) GetFaultSetByName(name string) (*types.FaultSet, error) {
-	allFaultSets, err := s.GetAllFaultSets()
+func (s *System) GetFaultSetByName(ctx context.Context, name string) (*types.FaultSet, error) {
+	allFaultSets, err := s.GetAllFaultSets(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/fault_set_test.go
+++ b/fault_set_test.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"math"
 	"net/http"
@@ -63,7 +64,7 @@ func TestCreateFaultSet(t *testing.T) {
 
 			p := NewProtectionDomain(client)
 
-			ID, errFs = p.CreateFaultSet(tc.fs)
+			ID, errFs = p.CreateFaultSet(context.Background(), tc.fs)
 			if errFs != nil {
 				if tc.expected == nil {
 					t.Errorf("Creating fault set did not work as expected, \n\tgot: %s \n\twant: %v", errFs, tc.expected)
@@ -107,7 +108,7 @@ func TestGetFaultByID(t *testing.T) {
 			s := System{
 				client: client,
 			}
-			_, err2 := s.GetFaultSetByID(tc.id)
+			_, err2 := s.GetFaultSetByID(context.Background(), tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Fetching fault set did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -154,7 +155,7 @@ func TestModifyFaultSetName(t *testing.T) {
 			p := ProtectionDomain{
 				client: client,
 			}
-			err2 := p.ModifyFaultSetName(tc.id, tc.name)
+			err2 := p.ModifyFaultSetName(context.Background(), tc.id, tc.name)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Modifying fault set did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -206,7 +207,7 @@ func TestModifyFaultPerfProfile(t *testing.T) {
 			p := ProtectionDomain{
 				client: client,
 			}
-			err2 := p.ModifyFaultSetPerfProfile(tc.id, tc.perfProfile)
+			err2 := p.ModifyFaultSetPerfProfile(context.Background(), tc.id, tc.perfProfile)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Modifying fault set did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -250,7 +251,7 @@ func TestDeleteFaultSet(t *testing.T) {
 			p := ProtectionDomain{
 				client: client,
 			}
-			err2 := p.DeleteFaultSet(tc.id)
+			err2 := p.DeleteFaultSet(context.Background(), tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Removing fault set did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -279,7 +280,7 @@ func TestGetAllFaultSets(t *testing.T) {
 		client: client,
 	}
 
-	faultsets, err := s.GetAllFaultSets()
+	faultsets, err := s.GetAllFaultSets(context.Background())
 	assert.Equal(t, len(faultsets), 0)
 	assert.Nil(t, err)
 }
@@ -315,7 +316,7 @@ func TestGetAllFaultSetsSds(t *testing.T) {
 			s := System{
 				client: client,
 			}
-			_, err2 := s.GetAllSDSByFaultSetID(tc.id)
+			_, err2 := s.GetAllSDSByFaultSetID(context.Background(), tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Getting sds related with fault set did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)

--- a/fs_test.go
+++ b/fs_test.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -189,7 +190,7 @@ func TestGetFileSystemByIDName(t *testing.T) {
 				client: client,
 			}
 
-			resp, err := s.GetFileSystemByIDName("", testCaseFSNames[name])
+			resp, err := s.GetFileSystemByIDName(context.Background(), "", testCaseFSNames[name])
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -211,7 +212,7 @@ func TestGetFileSystemByIDName(t *testing.T) {
 				client: client,
 			}
 
-			resp, err := s.GetFileSystemByIDName(testCaseFSIds[id], "")
+			resp, err := s.GetFileSystemByIDName(context.Background(), testCaseFSIds[id], "")
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -306,7 +307,7 @@ func TestCreateFileSystem(t *testing.T) {
 				NasServerID:   "64132f37-d33e-9d4a-89ba-d625520a4779",
 			}
 
-			resp, err := s.CreateFileSystem(fs)
+			resp, err := s.CreateFileSystem(context.Background(), fs)
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -400,7 +401,7 @@ func TestCreateFileSystemSnapshot(t *testing.T) {
 				Name: "test-snapshot",
 			}
 
-			resp, err := s.CreateFileSystemSnapshot(fsSnapRequest, fsID)
+			resp, err := s.CreateFileSystemSnapshot(context.Background(), fsSnapRequest, fsID)
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -499,7 +500,7 @@ func TestGetFsSnapshotsByVolumeID(t *testing.T) {
 
 			fsID := "64366a19-54e8-1544-f3d7-2a50fb1ccff3"
 
-			resp, err := s.GetFsSnapshotsByVolumeID(fsID)
+			resp, err := s.GetFsSnapshotsByVolumeID(context.Background(), fsID)
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -634,7 +635,7 @@ func TestRestoreFileSystemFromSnapshot(t *testing.T) {
 				}
 			}
 
-			resp, err := s.RestoreFileSystemFromSnapshot(restoreSnapshotRequest, fsID)
+			resp, err := s.RestoreFileSystemFromSnapshot(context.Background(), restoreSnapshotRequest, fsID)
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -660,7 +661,7 @@ func TestDeleteFileSystem(t *testing.T) {
 		client: client,
 	}
 
-	err = s.DeleteFileSystem(name)
+	err = s.DeleteFileSystem(context.Background(), name)
 	assert.NotNil(t, err)
 }
 
@@ -707,7 +708,7 @@ func TestModifyFileSystem(t *testing.T) {
 			}
 
 			// calling ModifyFileSystem with mock value
-			err = s.ModifyFileSystem(fsParam, tc.fsID)
+			err = s.ModifyFileSystem(context.Background(), fsParam, tc.fsID)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Modifying FS did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)

--- a/inttests/compliance_management_test.go
+++ b/inttests/compliance_management_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"testing"
 
 	siotypes "github.com/dell/goscaleio/types/v1"
@@ -22,7 +23,7 @@ import (
 // TestGetComplianceManagement tests compliance management get
 func TestGetComplianceManagement(t *testing.T) {
 	system := getSystem()
-	complianceReport, err := system.GetCompatibilityManagement()
+	complianceReport, err := system.GetCompatibilityManagement(context.Background())
 	assert.Nil(t, err)
 	assert.NotNil(t, complianceReport)
 }
@@ -30,7 +31,7 @@ func TestGetComplianceManagement(t *testing.T) {
 // TestSetComplianceManagement tests compliance management set
 func TestSetComplianceManagement(t *testing.T) {
 	system := getSystem()
-	complianceReport, err := system.SetCompatibilityManagement(&siotypes.CompatibilityManagementPost{
+	complianceReport, err := system.SetCompatibilityManagement(context.Background(), &siotypes.CompatibilityManagementPost{
 		Source:         "local",
 		RepositoryPath: "cm-20231005-01-test.gpg",
 		CompatibilityDataBytes: []byte{

--- a/inttests/fault_set_test.go
+++ b/inttests/fault_set_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -33,35 +34,37 @@ func TestCreateModifyDeleteFaultSet(t *testing.T) {
 		ProtectionDomainID: domain.ProtectionDomain.ID,
 	}
 
+	ctx := context.Background()
+
 	// create the fault set
-	fsID, err := domain.CreateFaultSet(fs)
+	fsID, err := domain.CreateFaultSet(ctx, fs)
 	assert.Nil(t, err)
 	assert.NotNil(t, fsID)
 
 	// create a fault set that exists
-	fsID2, err2 := domain.CreateFaultSet(fs)
+	fsID2, err2 := domain.CreateFaultSet(ctx, fs)
 	assert.NotNil(t, err2)
 	assert.Equal(t, "", fsID2)
 
 	// modify fault set name
-	err = domain.ModifyFaultSetName(fsID, "faultSetRenamed")
+	err = domain.ModifyFaultSetName(ctx, fsID, "faultSetRenamed")
 	assert.Nil(t, err)
 
 	// modify fault set performance profile
-	err = domain.ModifyFaultSetPerfProfile(fsID, "Compact")
+	err = domain.ModifyFaultSetPerfProfile(ctx, fsID, "Compact")
 	assert.Nil(t, err)
 	time.Sleep(5 * time.Second)
 
 	// read the fault set
-	fsr, err := system.GetFaultSetByID(fsID)
+	fsr, err := system.GetFaultSetByID(ctx, fsID)
 	assert.Equal(t, "faultSetRenamed", fsr.Name)
 
 	// delete the fault set
-	err = domain.DeleteFaultSet(fsID)
+	err = domain.DeleteFaultSet(ctx, fsID)
 	assert.Nil(t, err)
 
 	// try to delete non-existent fault set
-	err3 := domain.DeleteFaultSet(invalidIdentifier)
+	err3 := domain.DeleteFaultSet(ctx, invalidIdentifier)
 	assert.NotNil(t, err3)
 }
 
@@ -69,7 +72,7 @@ func TestGetAllFaultSets(t *testing.T) {
 	system := getSystem()
 	assert.NotNil(t, system)
 
-	_, err := system.GetAllFaultSets()
+	_, err := system.GetAllFaultSets(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -77,11 +80,13 @@ func TestGetSdsFaultSet(t *testing.T) {
 	system := getSystem()
 	assert.NotNil(t, system)
 
-	faultsets, err := system.GetAllFaultSets()
+	ctx := context.Background()
+
+	faultsets, err := system.GetAllFaultSets(ctx)
 	assert.Nil(t, err)
 
 	if len(faultsets) > 0 {
-		_, err = system.GetAllSDSByFaultSetID(faultsets[0].ID)
+		_, err = system.GetAllSDSByFaultSetID(ctx, faultsets[0].ID)
 		assert.Nil(t, err)
 	}
 }
@@ -98,11 +103,13 @@ func TestGetFaultSetByName(t *testing.T) {
 		ProtectionDomainID: domain.ProtectionDomain.ID,
 	}
 
+	ctx := context.Background()
+
 	// create the fault set
-	_, err := domain.CreateFaultSet(fs)
+	_, err := domain.CreateFaultSet(ctx, fs)
 	assert.Nil(t, err)
 
-	fsDetails, err := system.GetFaultSetByName(fsName)
+	fsDetails, err := system.GetFaultSetByName(ctx, fsName)
 	assert.NotNil(t, fsDetails)
 	assert.Nil(t, err)
 }

--- a/inttests/init_client.go
+++ b/inttests/init_client.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math"
@@ -47,7 +48,7 @@ func initClient() {
 	}
 
 	if C.GetToken() == "" {
-		_, err := C.Authenticate(&goscaleio.ConfigConnect{
+		_, err := C.Authenticate(context.Background(), &goscaleio.ConfigConnect{
 			Endpoint: os.Getenv(mainEndpoint),
 			Username: os.Getenv("GOSCALEIO_USERNAME"),
 			Password: os.Getenv("GOSCALEIO_PASSWORD"),
@@ -78,7 +79,7 @@ func initClient2() bool {
 	}
 
 	if C2.GetToken() == "" {
-		_, err := C2.Authenticate(&goscaleio.ConfigConnect{
+		_, err := C2.Authenticate(context.Background(), &goscaleio.ConfigConnect{
 			Endpoint: os.Getenv(replicationEnpoint),
 			Username: os.Getenv("GOSCALEIO_USERNAME2"),
 			Password: os.Getenv("GOSCALEIO_PASSWORD2"),

--- a/inttests/nfs_test.go
+++ b/inttests/nfs_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -27,7 +28,7 @@ func getNasName(t *testing.T) string {
 	}
 	system := getSystem()
 	assert.NotNil(t, system)
-	nasServer, _ := system.GetNASByIDName("", "")
+	nasServer, _ := system.GetNASByIDName(context.Background(), "", "")
 	assert.NotNil(t, nasServer)
 	if nasServer == nil {
 		return ""
@@ -44,18 +45,20 @@ func TestGetNASByIDName(t *testing.T) {
 	nasName := getNasName(t)
 	assert.NotZero(t, len(nasName))
 
-	nasserver, err := system.GetNASByIDName("", nasName)
+	ctx := context.Background()
+
+	nasserver, err := system.GetNASByIDName(ctx, "", nasName)
 	assert.Nil(t, err)
 	assert.Equal(t, nasName, nasserver.Name)
 
 	if nasserver != nil {
-		nas, err := system.GetNASByIDName(nasserver.ID, "")
+		nas, err := system.GetNASByIDName(ctx, nasserver.ID, "")
 		assert.Nil(t, err)
 		assert.Equal(t, nasserver.ID, nas.ID)
 	}
 
 	if len(nasName) > 0 {
-		nas, err := system.GetNASByIDName("", nasName)
+		nas, err := system.GetNASByIDName(ctx, "", nasName)
 		assert.Nil(t, err)
 		assert.Equal(t, nasName, nas.Name)
 	}
@@ -66,11 +69,13 @@ func TestGetNasByIDNameInvalid(t *testing.T) {
 	system := getSystem()
 	assert.NotNil(t, system)
 
-	nas, err := system.GetNASByIDName(invalidIdentifier, "")
+	ctx := context.Background()
+
+	nas, err := system.GetNASByIDName(ctx, invalidIdentifier, "")
 	assert.NotNil(t, err)
 	assert.Nil(t, nas)
 
-	nasName, err := system.GetNASByIDName("", invalidIdentifier)
+	nasName, err := system.GetNASByIDName(ctx, "", invalidIdentifier)
 	assert.NotNil(t, err)
 	assert.Nil(t, nasName)
 }
@@ -81,6 +86,8 @@ func TestCreateDeleteNAS(t *testing.T) {
 
 	nasName := fmt.Sprintf("%s-%s", testPrefix, "twee2")
 
+	ctx := context.Background()
+
 	// get protection domain
 	pd := getProtectionDomain(t)
 	assert.NotNil(t, pd)
@@ -88,26 +95,26 @@ func TestCreateDeleteNAS(t *testing.T) {
 	var pdID string
 
 	if pd != nil {
-		pDomain, _ := system.FindProtectionDomain(pd.ProtectionDomain.ID, "", "")
+		pDomain, _ := system.FindProtectionDomain(ctx, pd.ProtectionDomain.ID, "", "")
 		assert.NotNil(t, pDomain)
 		pdID = pDomain.ID
 	}
 
 	// create the NAS Server
-	nasID, err := system.CreateNAS(nasName, pdID)
+	nasID, err := system.CreateNAS(ctx, nasName, pdID)
 	assert.Nil(t, err)
 	assert.NotNil(t, nasID.ID)
 
 	// try to create a NAS Server that exists
-	_, err = system.CreateNAS(nasName, pdID)
+	_, err = system.CreateNAS(ctx, nasName, pdID)
 	assert.NotNil(t, err)
 
 	// delete the NAS Server
-	err = system.DeleteNAS(nasID.ID)
+	err = system.DeleteNAS(ctx, nasID.ID)
 	assert.Nil(t, err)
 
 	// try to delete non-existent NAS Server
-	err = system.DeleteNAS(nasID.ID)
+	err = system.DeleteNAS(ctx, nasID.ID)
 	assert.NotNil(t, err)
 }
 
@@ -116,12 +123,14 @@ func TestGetFileInterfaceById(t *testing.T) {
 	nasName := getNasName(t)
 	assert.NotZero(t, len(nasName))
 
-	nasserver, err := system.GetNASByIDName("", nasName)
+	ctx := context.Background()
+
+	nasserver, err := system.GetNASByIDName(ctx, "", nasName)
 	assert.Nil(t, err)
 	assert.Equal(t, nasName, nasserver.Name)
 
 	if nasserver != nil {
-		fileInterface, err := system.GetFileInterface(nasserver.CurrentPreferredIPv4InterfaceID)
+		fileInterface, err := system.GetFileInterface(ctx, nasserver.CurrentPreferredIPv4InterfaceID)
 		assert.Nil(t, err)
 		assert.NotNil(t, fileInterface)
 	}

--- a/inttests/nvme_host_test.go
+++ b/inttests/nvme_host_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -26,6 +27,7 @@ func TestNvmeHost(t *testing.T) {
 	name := fmt.Sprintf("nvme_%v", randString(10))
 	newName := fmt.Sprintf("nvme_new_%v", randString(10))
 	var hostID string
+	ctx := context.Background()
 
 	t.Run("Create NVMe Host", func(t *testing.T) {
 		assert.NotNil(t, system)
@@ -34,47 +36,47 @@ func TestNvmeHost(t *testing.T) {
 			Nqn:         fmt.Sprintf("nqn.2014-08.org.nvmexpress:uuid:%v", uuid.New()),
 			MaxNumPaths: 4,
 		}
-		resp, err := system.CreateNvmeHost(nvmeHostParam)
+		resp, err := system.CreateNvmeHost(ctx, nvmeHostParam)
 		assert.Nil(t, err)
 		assert.NotNil(t, resp.ID)
 		hostID = resp.ID
 	})
 
 	t.Run("Get All NVMe Hosts", func(t *testing.T) {
-		hosts, err := system.GetAllNvmeHosts()
+		hosts, err := system.GetAllNvmeHosts(ctx)
 		assert.Nil(t, err)
 		assert.NotNil(t, hosts)
 	})
 
 	t.Run("Get NVMe Host By ID", func(t *testing.T) {
-		host, err := system.GetNvmeHostByID(hostID)
+		host, err := system.GetNvmeHostByID(ctx, hostID)
 		assert.Nil(t, err)
 		assert.NotNil(t, host)
 	})
 
 	t.Run("Change NVMe Host Name", func(t *testing.T) {
-		err := system.ChangeNvmeHostName(hostID, newName)
+		err := system.ChangeNvmeHostName(ctx, hostID, newName)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Change NVMe Host MaxNumPaths", func(t *testing.T) {
-		err := system.ChangeNvmeHostMaxNumPaths(hostID, 6)
+		err := system.ChangeNvmeHostMaxNumPaths(ctx, hostID, 6)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Change NVMe Host MaxNumSysPorts", func(t *testing.T) {
-		err := system.ChangeNvmeHostMaxNumSysPorts(hostID, 8)
+		err := system.ChangeNvmeHostMaxNumSysPorts(ctx, hostID, 8)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Get Host NVMe Controllers", func(t *testing.T) {
-		controllers, err := system.GetHostNvmeControllers(types.NvmeHost{ID: hostID})
+		controllers, err := system.GetHostNvmeControllers(ctx, types.NvmeHost{ID: hostID})
 		assert.Nil(t, err)
 		assert.NotNil(t, controllers)
 	})
 
 	t.Cleanup(func() {
-		err := system.DeleteNvmeHost(hostID)
+		err := system.DeleteNvmeHost(ctx, hostID)
 		assert.Nil(t, err)
 	})
 }

--- a/inttests/os_repository_test.go
+++ b/inttests/os_repository_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ import (
 // TestOSRepositoryGetAll tests get All OS Repositories
 func TestOSRepositoryGetAll(t *testing.T) {
 	system := getSystem()
-	osRepositories, err := system.GetAllOSRepositories()
+	osRepositories, err := system.GetAllOSRepositories(context.Background())
 	assert.Nil(t, err)
 	assert.NotNil(t, osRepositories)
 }
@@ -31,7 +32,7 @@ func TestOSRepositoryGetAll(t *testing.T) {
 // TestOSRepositoryGetByID tests Get OS Repository by Id
 func TestOSRepositoryGetByID(t *testing.T) {
 	system := getSystem()
-	osRepository, err := system.GetOSRepositoryByID("8aaa80458fca6913018fce6449f50e81")
+	osRepository, err := system.GetOSRepositoryByID(context.Background(), "8aaa80458fca6913018fce6449f50e81")
 	assert.Nil(t, err)
 	assert.NotNil(t, osRepository)
 }
@@ -39,14 +40,14 @@ func TestOSRepositoryGetByID(t *testing.T) {
 // TestOSRepositoryGetByIDFail tests the negative case for Get OS Repository by Id
 func TestOSRepositoryGetByIDFail(t *testing.T) {
 	system := getSystem()
-	_, err := system.GetOSRepositoryByID("Invalid")
+	_, err := system.GetOSRepositoryByID(context.Background(), "Invalid")
 	assert.NotNil(t, err)
 }
 
 // TestGetOSRepositoryByIDFail tests the negative case for Get OS Repository by Id
 func TestOSRepositoryCreateFail(t *testing.T) {
 	system := getSystem()
-	_, err := system.CreateOSRepository(nil)
+	_, err := system.CreateOSRepository(context.Background(), nil)
 	assert.NotNil(t, err)
 }
 
@@ -54,7 +55,7 @@ func TestOSRepositoryCreateFail(t *testing.T) {
 func TestOSRepositoryDeleteFail(t *testing.T) {
 	system := getSystem()
 	// Delete
-	err := system.RemoveOSRepository("invalid")
+	err := system.RemoveOSRepository(context.Background(), "invalid")
 	assert.NotNil(t, err)
 }
 
@@ -67,15 +68,17 @@ func TestOSRepositoryCreateAndDelete(t *testing.T) {
 		SourcePath: "https://100.65.27.72/artifactory/vxfm-yum-release/pfmp20/RCM/Denver/RCMs/esxi/ESXi-8.0.0-20513097-3.8.0.0_Dell.iso",
 		ImageType:  "vmware_esxi",
 	}
+	ctx := context.Background()
+
 	// Create
-	osRepository, err := system.CreateOSRepository(createOSRepository)
+	osRepository, err := system.CreateOSRepository(ctx, createOSRepository)
 	assert.Nil(t, err)
 	assert.NotNil(t, osRepository)
 	// We will wait for Repository to be unpacked and created
 	time.Sleep(240 * time.Second)
 
 	var repoID string
-	osRepositories, err := system.GetAllOSRepositories()
+	osRepositories, err := system.GetAllOSRepositories(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, osRepositories)
 	for _, repo := range osRepositories {
@@ -86,6 +89,6 @@ func TestOSRepositoryCreateAndDelete(t *testing.T) {
 	}
 
 	// Delete
-	err = system.RemoveOSRepository(repoID)
+	err = system.RemoveOSRepository(ctx, repoID)
 	assert.Nil(t, err)
 }

--- a/inttests/replication_test.go
+++ b/inttests/replication_test.go
@@ -18,6 +18,7 @@
 package inttests
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -57,7 +58,8 @@ const (
 
 // Test GetPeerMDMs
 func TestGetPeerMDMs(t *testing.T) {
-	srcpeers, err := C.GetPeerMDMs()
+	ctx := context.Background()
+	srcpeers, err := C.GetPeerMDMs(ctx)
 	assert.Nil(t, err)
 
 	var sourceSystemID string
@@ -69,7 +71,7 @@ func TestGetPeerMDMs(t *testing.T) {
 		t.Skip("no client connection to replication target system")
 	}
 
-	tgtpeers, err := C2.GetPeerMDMs()
+	tgtpeers, err := C2.GetPeerMDMs(ctx)
 	assert.Nil(t, err)
 
 	var targetSystemID string
@@ -118,7 +120,7 @@ func TestGetPeerSystem(t *testing.T) {
 	srcpeer, err := getPeerMdm()
 	assert.Nil(t, err)
 
-	_, getErr := C.GetPeerMDM(srcpeer.ID)
+	_, getErr := C.GetPeerMDM(context.Background(), srcpeer.ID)
 	assert.Nil(t, getErr)
 }
 
@@ -127,7 +129,7 @@ func TestRemovePeerSystem(t *testing.T) {
 	srcpeer, err := getPeerMdm()
 	assert.Nil(t, err)
 
-	removeErr := C.RemovePeerMdm(srcpeer.ID)
+	removeErr := C.RemovePeerMdm(context.Background(), srcpeer.ID)
 	assert.Nil(t, removeErr)
 }
 
@@ -143,7 +145,7 @@ func TestAddPeerSystem(t *testing.T) {
 		Name:          "PeerSystemTestName",
 	}
 	// Add a Peer System
-	_, err := C.AddPeerMdm(peerPayload)
+	_, err := C.AddPeerMdm(context.Background(), peerPayload)
 	assert.Nil(t, err)
 }
 
@@ -151,15 +153,16 @@ func TestAddPeerSystem(t *testing.T) {
 func TestModifyPeerSystemName(t *testing.T) {
 	srcpeer, err := getPeerMdm()
 	assert.Nil(t, err)
+	ctx := context.Background()
 
 	// Modify name
-	modifyErr := C.ModifyPeerMdmName(srcpeer.ID, &siotypes.ModifyPeerMDMNameParam{
+	modifyErr := C.ModifyPeerMdmName(ctx, srcpeer.ID, &siotypes.ModifyPeerMDMNameParam{
 		NewName: "testName",
 	})
 	assert.Nil(t, modifyErr)
 
 	// Modify Name back to original
-	modifyErr = C.ModifyPeerMdmName(srcpeer.ID, &siotypes.ModifyPeerMDMNameParam{
+	modifyErr = C.ModifyPeerMdmName(ctx, srcpeer.ID, &siotypes.ModifyPeerMDMNameParam{
 		NewName: srcpeer.Name,
 	})
 }
@@ -168,15 +171,16 @@ func TestModifyPeerSystemName(t *testing.T) {
 func TestModifyPeerSystemPort(t *testing.T) {
 	srcpeer, err := getPeerMdm()
 	assert.Nil(t, err)
+	ctx := context.Background()
 
 	// Modify port
-	modifyErr := C.ModifyPeerMdmPort(srcpeer.ID, &siotypes.ModifyPeerMDMPortParam{
+	modifyErr := C.ModifyPeerMdmPort(ctx, srcpeer.ID, &siotypes.ModifyPeerMDMPortParam{
 		NewPort: "7612",
 	})
 	assert.Nil(t, modifyErr)
 
 	// Modify Name back to original
-	modifyErr = C.ModifyPeerMdmPort(srcpeer.ID, &siotypes.ModifyPeerMDMPortParam{
+	modifyErr = C.ModifyPeerMdmPort(ctx, srcpeer.ID, &siotypes.ModifyPeerMDMPortParam{
 		NewPort: fmt.Sprint(srcpeer.Port),
 	})
 }
@@ -185,15 +189,16 @@ func TestModifyPeerSystemPort(t *testing.T) {
 func TestModifyPeerSystemPerformanceParameters(t *testing.T) {
 	srcpeer, err := getPeerMdm()
 	assert.Nil(t, err)
+	ctx := context.Background()
 
 	// Modify port
-	modifyErr := C.ModifyPeerMdmPerformanceParameters(srcpeer.ID, &siotypes.ModifyPeerMdmPerformanceParametersParam{
+	modifyErr := C.ModifyPeerMdmPerformanceParameters(ctx, srcpeer.ID, &siotypes.ModifyPeerMdmPerformanceParametersParam{
 		NewPreformanceProfile: "Compact",
 	})
 	assert.Nil(t, modifyErr)
 
 	// Modify Name back to original
-	modifyErr = C.ModifyPeerMdmPerformanceParameters(srcpeer.ID, &siotypes.ModifyPeerMdmPerformanceParametersParam{
+	modifyErr = C.ModifyPeerMdmPerformanceParameters(ctx, srcpeer.ID, &siotypes.ModifyPeerMdmPerformanceParametersParam{
 		NewPreformanceProfile: srcpeer.PerfProfile,
 	})
 }
@@ -209,13 +214,13 @@ func TestModifyPeerSystemIps(t *testing.T) {
 	}
 
 	// Modify ips
-	modifyErr := C.ModifyPeerMdmIP(srcpeer.ID, ips)
+	modifyErr := C.ModifyPeerMdmIP(context.Background(), srcpeer.ID, ips)
 	assert.Nil(t, modifyErr)
 }
 
 // Make it easier to get a Peer System to run the tests against
 func getPeerMdm() (*siotypes.PeerMDM, error) {
-	srcpeers, err := C.GetPeerMDMs()
+	srcpeers, err := C.GetPeerMDMs(context.Background())
 
 	if err != nil || len(srcpeers) == 0 {
 		return nil, fmt.Errorf("no peer systems found")
@@ -226,7 +231,7 @@ func getPeerMdm() (*siotypes.PeerMDM, error) {
 // Get the Target System
 func getTargetSystem() *goscaleio.System {
 	system := goscaleio.NewSystem(C2)
-	targetSystems, _ := C2.GetSystems()
+	targetSystems, _ := C2.GetSystems(context.Background())
 
 	if len(targetSystems) > 0 {
 		system.System = targetSystems[0]
@@ -251,14 +256,14 @@ func TestGetProtectionDomain(t *testing.T) {
 	assert.NotNil(t, rep.sourceProtectionDomain)
 
 	href := "/api/instances/ProtectionDomain::" + rep.sourceProtectionDomain.ProtectionDomain.ID
-	_, err := getSystem().GetProtectionDomain(href)
+	_, err := getSystem().GetProtectionDomain(context.Background(), href)
 	assert.Nil(t, err)
 }
 
 // Get the Target Protection Domain
 func getTargetProtectionDomain() *goscaleio.ProtectionDomain {
 	targetProtectionDomainName := os.Getenv(targetProtectionDomain)
-	protectionDomains, _ := rep.targetSystem.GetProtectionDomain("")
+	protectionDomains, _ := rep.targetSystem.GetProtectionDomain(context.Background(), "")
 	for i := 0; i < len(protectionDomains); i++ {
 		if protectionDomains[i].Name == targetProtectionDomainName {
 			return goscaleio.NewProtectionDomainEx(C2, protectionDomains[i])
@@ -279,7 +284,7 @@ func TestTargetProtectionDomain(t *testing.T) {
 // Get the Target StoragePool
 func getTargetStoragePool() *goscaleio.StoragePool {
 	targetStoragePoolName := os.Getenv(targetStoragePool)
-	storagePools, _ := rep.targetProtectionDomain.GetStoragePool("")
+	storagePools, _ := rep.targetProtectionDomain.GetStoragePool(context.Background(), "")
 	for i := 0; i < len(storagePools); i++ {
 		if storagePools[i].Name == targetStoragePoolName {
 			return goscaleio.NewStoragePoolEx(C2, storagePools[i])
@@ -305,9 +310,11 @@ func TestLocateVolumesToBeReplicated(t *testing.T) {
 		t.Skip("no client connection to replication target system")
 	}
 
+	ctx := context.Background()
+
 	srcName := os.Getenv(sourceVolume)
 	assert.NotNil(t, srcName)
-	sourceVolumes, err := rep.sourceStoragePool.GetVolume("", "", "", srcName, false)
+	sourceVolumes, err := rep.sourceStoragePool.GetVolume(ctx, "", "", "", srcName, false)
 	if err != nil {
 		t.Log(err)
 	}
@@ -320,7 +327,7 @@ func TestLocateVolumesToBeReplicated(t *testing.T) {
 
 	dstName := os.Getenv(targetVolume)
 	assert.NotNil(t, dstName)
-	targetVolumes, err := rep.targetStoragePool.GetVolume("", "", "", dstName, false)
+	targetVolumes, err := rep.targetStoragePool.GetVolume(ctx, "", "", "", dstName, false)
 	if err != nil {
 		t.Log(err)
 	}
@@ -346,7 +353,7 @@ func TestCreateReplicationConsistencyGroup(t *testing.T) {
 		DestinationSystemID:      rep.targetSystem.System.ID,
 	}
 
-	rcgResp, err := C.CreateReplicationConsistencyGroup(rcgPayload)
+	rcgResp, err := C.CreateReplicationConsistencyGroup(context.Background(), rcgPayload)
 	assert.Nil(t, err)
 
 	log.Debugf("RCG ID: %s", rcgResp.ID)
@@ -361,7 +368,7 @@ func TestGetReplicationConsistencyGroups(t *testing.T) {
 		t.Skip("no client connection to replication target system")
 	}
 
-	rcgs, err := C.GetReplicationConsistencyGroups()
+	rcgs, err := C.GetReplicationConsistencyGroups(context.Background())
 	assert.Nil(t, err)
 	for i := 0; i < len(rcgs); i++ {
 		assert.Nil(t, err)
@@ -380,11 +387,12 @@ func TestAddReplicationPair(t *testing.T) {
 	if C2 == nil {
 		t.Skip("no client connection to replication target system")
 	}
+	ctx := context.Background()
 
 	srcName := os.Getenv(sourceVolume)
 	assert.NotNil(t, srcName)
 
-	localVolumeID, err := C.FindVolumeID(srcName)
+	localVolumeID, err := C.FindVolumeID(ctx, srcName)
 	assert.Nil(t, err)
 
 	t.Logf("[TestAddReplicationPair] Local Volume ID: %s", localVolumeID)
@@ -392,12 +400,12 @@ func TestAddReplicationPair(t *testing.T) {
 	dstName := os.Getenv(targetVolume)
 	assert.NotNil(t, dstName)
 
-	remoteVolumeID, err := C2.FindVolumeID(dstName)
+	remoteVolumeID, err := C2.FindVolumeID(ctx, dstName)
 	assert.Nil(t, err)
 
 	t.Logf("[TestAddReplicationPair] Remote Volume ID: %s", remoteVolumeID)
 
-	_, err = C.GetVolume("", strings.TrimSpace(localVolumeID), "", "", false)
+	_, err = C.GetVolume(ctx, "", strings.TrimSpace(localVolumeID), "", "", false)
 	assert.Nil(t, err)
 
 	rpPayload := &siotypes.QueryReplicationPair{
@@ -408,7 +416,7 @@ func TestAddReplicationPair(t *testing.T) {
 		CopyType:                      "OnlineCopy",
 	}
 
-	rpResp, err := C.CreateReplicationPair(rpPayload)
+	rpResp, err := C.CreateReplicationPair(ctx, rpPayload)
 	assert.Nil(t, err)
 
 	t.Logf("ReplicationPairID: %s", rpResp.ID)
@@ -426,7 +434,7 @@ func TestQueryReplicationPairs(t *testing.T) {
 		t.Skip("no client connection to replication target system")
 	}
 
-	pairs, err := rep.rcg.GetReplicationPairs()
+	pairs, err := rep.rcg.GetReplicationPairs(context.Background())
 	assert.Nil(t, err)
 
 	for _, pair := range pairs {
@@ -442,7 +450,7 @@ func TestQueryReplicationPair(t *testing.T) {
 		t.Skip("no client connection to replication target system")
 	}
 
-	pair, err := C.GetReplicationPair(rep.pair.ReplicaitonPair.ID)
+	pair, err := C.GetReplicationPair(context.Background(), rep.pair.ReplicaitonPair.ID)
 	assert.Nil(t, err)
 	assert.NotNil(t, pair)
 }
@@ -453,13 +461,15 @@ func TestPauseAndResumeReplicationPair(t *testing.T) {
 		t.Skip("no client connection to replication target system")
 	}
 
+	ctx := context.Background()
+
 	// Pause
-	pairP, err := C.PausePairInitialCopy(rep.pair.ReplicaitonPair.ID)
+	pairP, err := C.PausePairInitialCopy(ctx, rep.pair.ReplicaitonPair.ID)
 	assert.Nil(t, err)
 	assert.NotNil(t, pairP)
 
 	// Resume
-	pairR, err := C.ResumePairInitialCopy(rep.pair.ReplicaitonPair.ID)
+	pairR, err := C.ResumePairInitialCopy(ctx, rep.pair.ReplicaitonPair.ID)
 	assert.Nil(t, err)
 	assert.NotNil(t, pairR)
 }
@@ -471,15 +481,16 @@ func TestQueryReplicationPairsStatistics(t *testing.T) {
 	}
 
 	assert.NotNil(t, rep.pair)
+	ctx := context.Background()
 
 	t.Logf("Waiting for Replication Pair %s to be complete.", rep.pair.ReplicaitonPair.Name)
 	for i := 0; i < 30; i++ {
-		rpResp, err := rep.pair.GetReplicationPairStatistics()
+		rpResp, err := rep.pair.GetReplicationPairStatistics(ctx)
 		assert.Nil(t, err)
 
 		t.Logf("Copied %f", rpResp.InitialCopyProgress)
 
-		group, err := C.GetReplicationConsistencyGroupByID(rep.rcgID)
+		group, err := C.GetReplicationConsistencyGroupByID(ctx, rep.rcgID)
 		assert.Nil(t, err)
 
 		// Check if complete
@@ -498,7 +509,7 @@ func TestCreateReplicationConsistencyGroupSnapshot(t *testing.T) {
 		t.Skip("no client connection to replication target system")
 	}
 
-	resp, err := rep.rcg.CreateReplicationConsistencyGroupSnapshot()
+	resp, err := rep.rcg.CreateReplicationConsistencyGroupSnapshot(context.Background())
 	assert.Nil(t, err)
 
 	t.Logf("Consistency Group Snapshot ID: %s", resp.SnapshotGroupID)
@@ -510,8 +521,9 @@ func TestSnapshotRetrieval(t *testing.T) {
 	if C2 == nil {
 		t.Skip("no client connection to replication target system")
 	}
+	ctx := context.Background()
 
-	pairs, err := rep.rcg.GetReplicationPairs()
+	pairs, err := rep.rcg.GetReplicationPairs(ctx)
 	assert.Nil(t, err)
 
 	var vols []string
@@ -522,7 +534,7 @@ func TestSnapshotRetrieval(t *testing.T) {
 
 	actionAttributes := make(map[string]string)
 	for _, vol := range vols {
-		result, err := C2.GetVolume("", "", vol, "", false)
+		result, err := C2.GetVolume(ctx, "", "", vol, "", false)
 		if err != nil {
 			t.Errorf("Get Vols Error: %s\n", err.Error())
 		} else {
@@ -543,7 +555,7 @@ func TestExecuteFailoverOnReplicationGroup(t *testing.T) {
 		t.Skip("no client connection to replication target system")
 	}
 
-	err := rep.rcg.ExecuteFailoverOnReplicationGroup()
+	err := rep.rcg.ExecuteFailoverOnReplicationGroup(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -556,7 +568,7 @@ func TestExecuteRestoreOnReplicationGroup(t *testing.T) {
 	err := ensureFailover(t)
 	assert.Nil(t, err)
 
-	err = rep.rcg.ExecuteRestoreOnReplicationGroup()
+	err = rep.rcg.ExecuteRestoreOnReplicationGroup(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -569,7 +581,7 @@ func TestExecuteSwitchoverOnReplicationGroup(t *testing.T) {
 	err := waitForConsistency(t)
 	assert.Nil(t, err)
 
-	err = rep.rcg.ExecuteSwitchoverOnReplicationGroup(false)
+	err = rep.rcg.ExecuteSwitchoverOnReplicationGroup(context.Background(), false)
 	assert.Nil(t, err)
 }
 
@@ -582,7 +594,7 @@ func TestExecuteReverseOnReplicationGroup(t *testing.T) {
 	err := ensureFailover(t)
 	assert.Nil(t, err)
 
-	err = rep.rcg.ExecuteReverseOnReplicationGroup()
+	err = rep.rcg.ExecuteReverseOnReplicationGroup(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -595,7 +607,7 @@ func TestExecutePauseOnReplicationGroup(t *testing.T) {
 	err := waitForConsistency(t)
 	assert.Nil(t, err)
 
-	err = rep.rcg.ExecutePauseOnReplicationGroup()
+	err = rep.rcg.ExecutePauseOnReplicationGroup(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -605,7 +617,7 @@ func TestExecuteResumeOnReplicationGroup(t *testing.T) {
 		t.Skip("no client connection to replication target system")
 	}
 
-	err := rep.rcg.ExecuteResumeOnReplicationGroup()
+	err := rep.rcg.ExecuteResumeOnReplicationGroup(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -614,7 +626,7 @@ func TestSetRPOOnReplicationGroup(t *testing.T) {
 	// Set the RCG context
 	TestGetReplicationConsistencyGroups(t)
 	// Update the RPO
-	err := rep.rcg.SetRPOOnReplicationGroup(siotypes.SetRPOReplicationConsistencyGroup{RpoInSeconds: "60"})
+	err := rep.rcg.SetRPOOnReplicationGroup(context.Background(), siotypes.SetRPOReplicationConsistencyGroup{RpoInSeconds: "60"})
 	assert.Nil(t, err)
 }
 
@@ -622,7 +634,7 @@ func TestSetRPOOnReplicationGroup(t *testing.T) {
 func TestSetTargetVolumeAccessModeOnReplicationGroup(t *testing.T) {
 	// Set the RCG context
 	TestGetReplicationConsistencyGroups(t)
-	err := rep.rcg.SetTargetVolumeAccessModeOnReplicationGroup(siotypes.SetTargetVolumeAccessModeOnReplicationGroup{TargetVolumeAccessMode: "ReadOnly"})
+	err := rep.rcg.SetTargetVolumeAccessModeOnReplicationGroup(context.Background(), siotypes.SetTargetVolumeAccessModeOnReplicationGroup{TargetVolumeAccessMode: "ReadOnly"})
 	assert.Nil(t, err)
 }
 
@@ -630,11 +642,13 @@ func TestSetTargetVolumeAccessModeOnReplicationGroup(t *testing.T) {
 func TestSetNewNameOnReplicationGroup(t *testing.T) {
 	// Set the RCG context
 	TestGetReplicationConsistencyGroups(t)
-	err := rep.rcg.SetNewNameOnReplicationGroup(siotypes.SetNewNameOnReplicationGroup{NewName: "UpdatedNameRCG"})
+	ctx := context.Background()
+
+	err := rep.rcg.SetNewNameOnReplicationGroup(ctx, siotypes.SetNewNameOnReplicationGroup{NewName: "UpdatedNameRCG"})
 	assert.Nil(t, err)
 	// Sleep for 10 to make sure the name is updated, then update it back to the original name
 	time.Sleep(10 * time.Second)
-	err = rep.rcg.SetNewNameOnReplicationGroup(siotypes.SetNewNameOnReplicationGroup{NewName: "inttestrcg"})
+	err = rep.rcg.SetNewNameOnReplicationGroup(ctx, siotypes.SetNewNameOnReplicationGroup{NewName: "inttestrcg"})
 	assert.Nil(t, err)
 }
 
@@ -642,7 +656,7 @@ func TestSetNewNameOnReplicationGroup(t *testing.T) {
 func TestExecuteInconsistentOnReplicationGroup(t *testing.T) {
 	// Set the RCG context
 	TestGetReplicationConsistencyGroups(t)
-	err := rep.rcg.ExecuteInconsistentOnReplicationGroup()
+	err := rep.rcg.ExecuteInconsistentOnReplicationGroup(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -650,7 +664,7 @@ func TestExecuteInconsistentOnReplicationGroup(t *testing.T) {
 func TestExecuteConsistentOnReplicationGroup(t *testing.T) {
 	// Set the RCG context
 	TestGetReplicationConsistencyGroups(t)
-	err := rep.rcg.ExecuteConsistentOnReplicationGroup()
+	err := rep.rcg.ExecuteConsistentOnReplicationGroup(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -658,7 +672,7 @@ func TestExecuteConsistentOnReplicationGroup(t *testing.T) {
 func TestExecuteTerminateOnReplicationGroup(t *testing.T) {
 	// Set the RCG context
 	TestGetReplicationConsistencyGroups(t)
-	err := rep.rcg.ExecuteTerminateOnReplicationGroup()
+	err := rep.rcg.ExecuteTerminateOnReplicationGroup(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -666,7 +680,7 @@ func TestExecuteTerminateOnReplicationGroup(t *testing.T) {
 func TestExecuteActivateOnReplicationGroup(t *testing.T) {
 	// Set the RCG context
 	TestGetReplicationConsistencyGroups(t)
-	err := rep.rcg.ExecuteActivateOnReplicationGroup()
+	err := rep.rcg.ExecuteActivateOnReplicationGroup(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -678,6 +692,7 @@ func TestResizeReplicationPair(t *testing.T) {
 
 	t.Logf("[TestResizeReplicationPair]  Failing over to get DR in Neutral state..")
 	TestExecuteFailoverOnReplicationGroup(t)
+	ctx := context.Background()
 
 	err := ensureFailover(t)
 	assert.Nil(t, err)
@@ -685,20 +700,20 @@ func TestResizeReplicationPair(t *testing.T) {
 	srcName := os.Getenv(sourceVolume)
 	assert.NotNil(t, srcName)
 
-	localVolumeID, err := C.FindVolumeID(srcName)
+	localVolumeID, err := C.FindVolumeID(ctx, srcName)
 	assert.Nil(t, err)
 
 	dstName := os.Getenv(targetVolume)
 	assert.NotNil(t, dstName)
 
-	remoteVolumeID, err := C2.FindVolumeID(dstName)
+	remoteVolumeID, err := C2.FindVolumeID(ctx, dstName)
 	assert.Nil(t, err)
 
-	sourceVol, err := C.GetVolume("", strings.TrimSpace(localVolumeID), "", "", false)
+	sourceVol, err := C.GetVolume(ctx, "", strings.TrimSpace(localVolumeID), "", "", false)
 	assert.Nil(t, err)
 	assert.NotNil(t, sourceVol)
 
-	destVol, err := C2.GetVolume("", strings.TrimSpace(remoteVolumeID), "", "", false)
+	destVol, err := C2.GetVolume(ctx, "", strings.TrimSpace(remoteVolumeID), "", "", false)
 	assert.Nil(t, err)
 	assert.NotNil(t, destVol)
 
@@ -707,7 +722,7 @@ func TestResizeReplicationPair(t *testing.T) {
 	volume.Volume = destVol[0]
 	existingSizeGB := volume.Volume.SizeInKb / (1024 * 1024)
 	newSize := existingSizeGB * 2
-	err = volume.SetVolumeSize(strconv.Itoa(int(newSize)))
+	err = volume.SetVolumeSize(ctx, strconv.Itoa(int(newSize)))
 	assert.Nil(t, err)
 
 	// Delay to ensure that the destination syncs up...
@@ -718,7 +733,7 @@ func TestResizeReplicationPair(t *testing.T) {
 	existingSizeGB = volume.Volume.SizeInKb / (1024 * 1024)
 	newSize = existingSizeGB * 2
 	// double the szie of the volume
-	err = volume.SetVolumeSize(strconv.Itoa(int(newSize)))
+	err = volume.SetVolumeSize(ctx, strconv.Itoa(int(newSize)))
 	assert.Nil(t, err)
 
 	// Restart the initial copy process?
@@ -732,8 +747,9 @@ func TestRemoveReplicationPairFromVolume(t *testing.T) {
 	if C2 == nil {
 		t.Skip("no client connection to replication target system")
 	}
+	ctx := context.Background()
 
-	pairs, err := C.GetAllReplicationPairs()
+	pairs, err := C.GetAllReplicationPairs(ctx)
 	assert.Nil(t, err)
 
 	var replicationPairID string
@@ -749,7 +765,7 @@ func TestRemoveReplicationPairFromVolume(t *testing.T) {
 		assert.NotNil(t, replicationPairID)
 	}
 
-	_, err = rep.pair.RemoveReplicationPair(true)
+	_, err = rep.pair.RemoveReplicationPair(ctx, true)
 	assert.Nil(t, err)
 
 	t.Logf("[TestRemoveReplicationPairFromVolume] Removed the following pair %s", rep.pair.ReplicaitonPair.Name)
@@ -764,7 +780,7 @@ func TestFreezeReplcationGroup(t *testing.T) {
 		t.Skip("no client connection to replication target system")
 	}
 
-	err := rep.rcg.FreezeReplicationConsistencyGroup(rep.rcgID)
+	err := rep.rcg.FreezeReplicationConsistencyGroup(context.Background(), rep.rcgID)
 	assert.Nil(t, err)
 
 	// Delay to verify on the UI.
@@ -779,7 +795,7 @@ func TestUnfreezeReplcationGroup(t *testing.T) {
 	TestGetReplicationConsistencyGroups(t)
 	assert.NotNil(t, rep.rcg)
 
-	err := rep.rcg.UnfreezeReplicationConsistencyGroup()
+	err := rep.rcg.UnfreezeReplicationConsistencyGroup(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -791,7 +807,7 @@ func TestRemoveReplicationConsistencyGroup(t *testing.T) {
 	TestGetReplicationConsistencyGroups(t)
 	assert.NotNil(t, rep.rcg)
 
-	err := rep.rcg.RemoveReplicationConsistencyGroup(false)
+	err := rep.rcg.RemoveReplicationConsistencyGroup(context.Background(), false)
 	assert.Nil(t, err)
 }
 
@@ -810,7 +826,7 @@ func parseLinks(links []*siotypes.Link, t *testing.T) {
 
 func waitForConsistency(t *testing.T) error {
 	for i := 0; i < 15; i++ {
-		group, err := C.GetReplicationConsistencyGroupByID(rep.rcgID)
+		group, err := C.GetReplicationConsistencyGroupByID(context.Background(), rep.rcgID)
 		if err != nil {
 			continue
 		}
@@ -827,7 +843,7 @@ func waitForConsistency(t *testing.T) error {
 
 func ensureFailover(t *testing.T) error {
 	for i := 0; i < 30; i++ {
-		group, err := C.GetReplicationConsistencyGroupByID(rep.rcgID)
+		group, err := C.GetReplicationConsistencyGroupByID(context.Background(), rep.rcgID)
 		if err != nil {
 			return errors.New("No replication consistency groups found: %")
 		}

--- a/inttests/sdc_test.go
+++ b/inttests/sdc_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dell/goscaleio"
@@ -29,7 +30,7 @@ func getAllSdc(t *testing.T) []*goscaleio.Sdc {
 	}
 
 	var allSdc []*goscaleio.Sdc
-	sdc, err := system.GetSdc()
+	sdc, err := system.GetSdc(context.Background())
 	assert.Nil(t, err)
 	assert.NotZero(t, len(sdc))
 	for _, s := range sdc {
@@ -46,6 +47,7 @@ func TestGetSdcs(t *testing.T) {
 
 // TestGetSdcByAttribute gets a single specific Sdc by attribute
 func TestGetSdcByAttribute(t *testing.T) {
+	ctx := context.Background()
 	system := getSystem()
 	assert.NotNil(t, system)
 	if system == nil {
@@ -58,17 +60,17 @@ func TestGetSdcByAttribute(t *testing.T) {
 		return
 	}
 
-	found, err := system.FindSdc("Name", Sdc[0].Sdc.Name)
+	found, err := system.FindSdc(ctx, "Name", Sdc[0].Sdc.Name)
 	assert.Nil(t, err)
 	assert.NotNil(t, found)
 	assert.Equal(t, Sdc[0].Sdc.Name, found.Sdc.Name)
 
-	found, err = system.FindSdc("ID", Sdc[0].Sdc.ID)
+	found, err = system.FindSdc(ctx, "ID", Sdc[0].Sdc.ID)
 	assert.Nil(t, err)
 	assert.NotNil(t, found)
 	assert.Equal(t, Sdc[0].Sdc.ID, found.Sdc.ID)
 
-	found, err = system.FindSdc("SdcGUID", Sdc[0].Sdc.SdcGUID)
+	found, err = system.FindSdc(ctx, "SdcGUID", Sdc[0].Sdc.SdcGUID)
 	assert.Nil(t, err)
 	assert.NotNil(t, found)
 	assert.Equal(t, Sdc[0].Sdc.SdcGUID, found.Sdc.SdcGUID)
@@ -77,6 +79,7 @@ func TestGetSdcByAttribute(t *testing.T) {
 // TestGetSdcByAttributeInvalid fails to get a single specific Sdc by attribute
 func TestGetSdcByAttributeInvalid(t *testing.T) {
 	system := getSystem()
+	ctx := context.Background()
 	assert.NotNil(t, system)
 	if system == nil {
 		return
@@ -87,11 +90,11 @@ func TestGetSdcByAttributeInvalid(t *testing.T) {
 		return
 	}
 
-	found, err := system.FindSdc("Name", invalidIdentifier)
+	found, err := system.FindSdc(ctx, "Name", invalidIdentifier)
 	assert.NotNil(t, err)
 	assert.Nil(t, found)
 
-	found, err = system.FindSdc("ID", invalidIdentifier)
+	found, err = system.FindSdc(ctx, "ID", invalidIdentifier)
 	assert.NotNil(t, err)
 	assert.Nil(t, found)
 }
@@ -105,7 +108,7 @@ func TestGetSdcStatistics(t *testing.T) {
 	}
 
 	for _, s := range Sdc {
-		stats, err := s.GetStatistics()
+		stats, err := s.GetStatistics(context.Background())
 		assert.Nil(t, err)
 		assert.NotNil(t, stats)
 	}
@@ -120,7 +123,7 @@ func TestGetSdcVolumes(t *testing.T) {
 	}
 
 	for _, s := range Sdc {
-		_, err := s.GetVolume()
+		_, err := s.GetVolume(context.Background())
 		assert.Nil(t, err)
 	}
 }
@@ -134,93 +137,98 @@ func TestFindSdcVolumes(t *testing.T) {
 	}
 
 	for _, s := range Sdc {
-		_, err := s.FindVolumes()
+		_, err := s.FindVolumes(context.Background())
 		assert.Nil(t, err)
 	}
 }
 
 // TestChangeSdcName function tests Change name functionality of SDC.
 func TestChangeSdcName(t *testing.T) {
+	ctx := context.Background()
 	system := getSystem()
 	assert.NotNil(t, system)
 
-	sdc, err := system.GetSdc()
+	sdc, err := system.GetSdc(ctx)
 	assert.Nil(t, err)
 	firstSdc := sdc[0]
 
 	baseName := firstSdc.Name
-	nameChng, err := system.ChangeSdcName(firstSdc.ID, randString(10))
+	nameChng, err := system.ChangeSdcName(ctx, firstSdc.ID, randString(10))
 	assert.Nil(t, err)
 	assert.NotNil(t, nameChng)
-	nameChngBack, err := system.ChangeSdcName(firstSdc.ID, baseName)
+	nameChngBack, err := system.ChangeSdcName(ctx, firstSdc.ID, baseName)
 	assert.Nil(t, err)
 	assert.NotNil(t, nameChngBack)
 }
 
 // TestChangeSdcPerfProfile function tests Change PerfProfile functionality of SDC.
 func TestChangeSdcPerfProfile(t *testing.T) {
+	ctx := context.Background()
 	system := getSystem()
 	assert.NotNil(t, system)
 
-	sdc, err := system.GetSdc()
+	sdc, err := system.GetSdc(ctx)
 	assert.Nil(t, err)
 	firstSdc := sdc[0]
 
 	basePerfProgile := firstSdc.PerfProfile
-	ppChng, err := system.ChangeSdcPerfProfile(firstSdc.ID, "Compact")
+	ppChng, err := system.ChangeSdcPerfProfile(ctx, firstSdc.ID, "Compact")
 	assert.Nil(t, err)
 	assert.NotNil(t, ppChng)
-	nameChngBack, err := system.ChangeSdcPerfProfile(firstSdc.ID, basePerfProgile)
+	nameChngBack, err := system.ChangeSdcPerfProfile(ctx, firstSdc.ID, basePerfProgile)
 	assert.Nil(t, err)
 	assert.NotNil(t, nameChngBack)
 }
 
 // TestDeleteSdc will attempt to delete an SDS, which results in faliure
 func TestDeleteSdc(t *testing.T) {
+	ctx := context.Background()
 	system := getSystem()
 	assert.NotNil(t, system)
 
-	sdc, err := system.GetSdc()
+	sdc, err := system.GetSdc(ctx)
 	assert.Nil(t, err)
 	firstSdc := sdc[0]
 
 	sdsID := firstSdc.ID
-	err = system.DeleteSdc(sdsID)
+	err = system.DeleteSdc(ctx, sdsID)
 	assert.NotNil(t, err)
 }
 
 // GetSdcIdByIP will attempt to get SDC ID By IP Address
 func TestGetSdcIdByIP(t *testing.T) {
+	ctx := context.Background()
 	system := getSystem()
 	assert.NotNil(t, system)
 
-	sdc, err := system.GetSdc()
+	sdc, err := system.GetSdc(ctx)
 	assert.Nil(t, err)
 	firstSdc := sdc[0]
 
 	sdsIP := firstSdc.SdcIP
-	sdcID, err := system.GetSdcIDByIP(sdsIP)
+	sdcID, err := system.GetSdcIDByIP(ctx, sdsIP)
 	assert.NotNil(t, sdcID)
 	assert.Nil(t, err)
 }
 
 func TestSdcRestrictedMode(t *testing.T) {
+	ctx := context.Background()
 	system := getSystem()
 	assert.NotNil(t, system)
 
-	err := system.SetRestrictedMode("Guid")
+	err := system.SetRestrictedMode(ctx, "Guid")
 	assert.Nil(t, err)
 
 	param := &types.ApproveSdcParam{
 		SdcIP: "10.10.10.10",
 	}
 
-	_, err = system.ApproveSdc(param)
+	_, err = system.ApproveSdc(ctx, param)
 	assert.NotNil(t, err)
 
-	err = system.SetApprovedIps("62276a432d28538a", []string{"10.10.10.10"})
+	err = system.SetApprovedIps(ctx, "62276a432d28538a", []string{"10.10.10.10"})
 	assert.NotNil(t, err)
 
-	err = system.SetRestrictedMode("None")
+	err = system.SetRestrictedMode(ctx, "None")
 	assert.Nil(t, err)
 }

--- a/inttests/sdt_test.go
+++ b/inttests/sdt_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -27,6 +28,7 @@ func TestSdt(t *testing.T) {
 	name := fmt.Sprintf("example-sdt_%v", randString(5))
 	newName := fmt.Sprintf("example-sdt_%v", randString(10))
 	var sdtID string
+	ctx := context.Background()
 
 	t.Run("Create sdt", func(t *testing.T) {
 		assert.NotNil(t, system)
@@ -42,7 +44,7 @@ func TestSdt(t *testing.T) {
 			DiscoveryPort:      8009,
 			ProtectionDomainID: pd.ProtectionDomain.ID,
 		}
-		resp, err := pd.CreateSdt(sdtParam)
+		resp, err := pd.CreateSdt(ctx, sdtParam)
 		assert.Nil(t, err)
 		assert.NotNil(t, resp.ID)
 		sdtID = resp.ID
@@ -50,72 +52,72 @@ func TestSdt(t *testing.T) {
 
 	t.Run("Remove Sdt Target IP", func(t *testing.T) {
 		targetIP := os.Getenv("NVME_TARGET_IP2")
-		err := system.RemoveSdtTargetIP(sdtID, targetIP)
+		err := system.RemoveSdtTargetIP(ctx, sdtID, targetIP)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Add Sdt Target IP", func(t *testing.T) {
 		targetIP := os.Getenv("NVME_TARGET_IP2")
-		err := system.AddSdtTargetIP(sdtID, targetIP, "StorageAndHost")
+		err := system.AddSdtTargetIP(ctx, sdtID, targetIP, "StorageAndHost")
 		assert.Nil(t, err)
 	})
 
 	t.Run("Get All Sdt", func(t *testing.T) {
-		hosts, err := system.GetAllSdts()
+		hosts, err := system.GetAllSdts(ctx)
 		assert.Nil(t, err)
 		assert.NotNil(t, hosts)
 	})
 
 	t.Run("Get Sdt By ID", func(t *testing.T) {
-		host, err := system.GetSdtByID(sdtID)
+		host, err := system.GetSdtByID(ctx, sdtID)
 		assert.Nil(t, err)
 		assert.NotNil(t, host)
 	})
 
 	t.Run("Rename Sdt", func(t *testing.T) {
-		err := system.RenameSdt(sdtID, newName)
+		err := system.RenameSdt(ctx, sdtID, newName)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Set Sdt NvmePort", func(t *testing.T) {
-		err := system.SetSdtNvmePort(sdtID, 4422)
+		err := system.SetSdtNvmePort(ctx, sdtID, 4422)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Set Sdt StoragePort", func(t *testing.T) {
-		err := system.SetSdtStoragePort(sdtID, 12300)
+		err := system.SetSdtStoragePort(ctx, sdtID, 12300)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Set Sdt DiscoveryPort", func(t *testing.T) {
-		err := system.SetSdtDiscoveryPort(sdtID, 8010)
+		err := system.SetSdtDiscoveryPort(ctx, sdtID, 8010)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Modify Sdt IP and Role", func(t *testing.T) {
 		targetIP := os.Getenv("NVME_TARGET_IP2")
-		err := system.ModifySdtIPRole(sdtID, targetIP, "StorageOnly")
+		err := system.ModifySdtIPRole(ctx, sdtID, targetIP, "StorageOnly")
 		assert.Nil(t, err)
 	})
 
 	t.Run("Rollback Sdt StoragePort", func(t *testing.T) {
-		err := system.SetSdtStoragePort(sdtID, 12200)
+		err := system.SetSdtStoragePort(ctx, sdtID, 12200)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Enter Sdt Maintenance Mode", func(t *testing.T) {
-		err := system.EnterSdtMaintenanceMode(sdtID)
+		err := system.EnterSdtMaintenanceMode(ctx, sdtID)
 		assert.Nil(t, err)
 	})
 
 	t.Run("Exit Sdt Maintenance Mode", func(t *testing.T) {
-		err := system.ExitSdtMaintenanceMode(sdtID)
+		err := system.ExitSdtMaintenanceMode(ctx, sdtID)
 		assert.Nil(t, err)
 		time.Sleep(5 * time.Second)
 	})
 
 	t.Cleanup(func() {
-		err := system.DeleteNvmeHost(sdtID)
+		err := system.DeleteNvmeHost(ctx, sdtID)
 		assert.Nil(t, err)
 	})
 }

--- a/inttests/snapshot_policy_test.go
+++ b/inttests/snapshot_policy_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -25,6 +26,7 @@ func TestCreateModifyDeleteSnapshotPolicy(t *testing.T) {
 	system := getSystem()
 	assert.NotNil(t, system)
 	spName := fmt.Sprintf("%s-%s", testPrefix, "SnapPolicy")
+	ctx := context.Background()
 
 	snap := &types.SnapshotPolicyCreateParam{
 		Name:                             spName,
@@ -35,17 +37,17 @@ func TestCreateModifyDeleteSnapshotPolicy(t *testing.T) {
 	}
 
 	// create the snapshot policy
-	snapID, err := system.CreateSnapshotPolicy(snap)
+	snapID, err := system.CreateSnapshotPolicy(ctx, snap)
 	assert.Nil(t, err)
 	assert.NotNil(t, snapID)
 	time.Sleep(5 * time.Second)
 
 	// create a snapsshot policy that exists
-	_, err2 := system.CreateSnapshotPolicy(snap)
+	_, err2 := system.CreateSnapshotPolicy(ctx, snap)
 	assert.NotNil(t, err2)
 
 	// modify snapshot policy name
-	err = system.RenameSnapshotPolicy(snapID, "SnapshotPolicyRenamed")
+	err = system.RenameSnapshotPolicy(ctx, snapID, "SnapshotPolicyRenamed")
 	assert.Nil(t, err)
 
 	// modify other parameters of snapshot policy
@@ -53,7 +55,7 @@ func TestCreateModifyDeleteSnapshotPolicy(t *testing.T) {
 		AutoSnapshotCreationCadenceInMin: "6",
 		NumOfRetainedSnapshotsPerLevel:   []string{"2", "6"},
 	}
-	err = system.ModifySnapshotPolicy(snapModify, snapID)
+	err = system.ModifySnapshotPolicy(ctx, snapModify, snapID)
 	assert.Nil(t, err)
 
 	volID, err := createVolume(t, "")
@@ -62,51 +64,51 @@ func TestCreateModifyDeleteSnapshotPolicy(t *testing.T) {
 	}
 
 	// Assign and unassign volume to Snapshot Policy
-	err = system.AssignVolumeToSnapshotPolicy(assignVolume, snapID)
+	err = system.AssignVolumeToSnapshotPolicy(ctx, assignVolume, snapID)
 	assert.Nil(t, err)
 
-	vol, err2 := system.GetSourceVolume(snapID)
+	vol, err2 := system.GetSourceVolume(ctx, snapID)
 	assert.Nil(t, err2)
 	assert.NotNil(t, vol)
 
 	assignVolume = &types.AssignVolumeToSnapshotPolicyParam{
 		SourceVolumeID: "Invalid",
 	}
-	err = system.AssignVolumeToSnapshotPolicy(assignVolume, snapID)
+	err = system.AssignVolumeToSnapshotPolicy(ctx, assignVolume, snapID)
 	assert.NotNil(t, err)
 
 	unassignVolume := &types.AssignVolumeToSnapshotPolicyParam{
 		SourceVolumeID:            volID,
 		AutoSnapshotRemovalAction: "Remove",
 	}
-	err = system.UnassignVolumeFromSnapshotPolicy(unassignVolume, snapID)
+	err = system.UnassignVolumeFromSnapshotPolicy(ctx, unassignVolume, snapID)
 	assert.Nil(t, err)
 
 	unassignVolume = &types.AssignVolumeToSnapshotPolicyParam{
 		SourceVolumeID:            volID,
 		AutoSnapshotRemovalAction: "Invalid",
 	}
-	err = system.UnassignVolumeFromSnapshotPolicy(unassignVolume, snapID)
+	err = system.UnassignVolumeFromSnapshotPolicy(ctx, unassignVolume, snapID)
 	assert.NotNil(t, err)
 
 	// Resume and Pause the SnapshotPolicy
-	err = system.ResumeSnapshotPolicy(snapID)
+	err = system.ResumeSnapshotPolicy(ctx, snapID)
 	assert.Nil(t, err)
 
-	err = system.ResumeSnapshotPolicy("Invalid")
+	err = system.ResumeSnapshotPolicy(ctx, "Invalid")
 	assert.NotNil(t, err)
 
-	err = system.PauseSnapshotPolicy(snapID)
+	err = system.PauseSnapshotPolicy(ctx, snapID)
 	assert.Nil(t, err)
 
-	err = system.PauseSnapshotPolicy("Invalid")
+	err = system.PauseSnapshotPolicy(ctx, "Invalid")
 	assert.NotNil(t, err)
 
 	// delete the snapshot policy
-	err = system.RemoveSnapshotPolicy(snapID)
+	err = system.RemoveSnapshotPolicy(ctx, snapID)
 	assert.Nil(t, err)
 
 	// try to delete non-existent snapsot policy
-	err = system.RemoveSnapshotPolicy(invalidIdentifier)
+	err = system.RemoveSnapshotPolicy(ctx, invalidIdentifier)
 	assert.NotNil(t, err)
 }

--- a/inttests/sso_user_test.go
+++ b/inttests/sso_user_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"testing"
 
 	types "github.com/dell/goscaleio/types/v1"
@@ -20,7 +21,9 @@ import (
 )
 
 func TestCreateAndDeleteSSOUser(t *testing.T) {
-	details, err := C.CreateSSOUser(&types.SSOUserCreateParam{
+	ctx := context.Background()
+
+	details, err := C.CreateSSOUser(ctx, &types.SSOUserCreateParam{
 		UserName: "IntegrationTestSSOUser",
 		Role:     "Monitor",
 		Password: "Ssouser123!",
@@ -29,23 +32,23 @@ func TestCreateAndDeleteSSOUser(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEmpty(t, details)
 
-	details, err = C.GetSSOUser(details.ID)
+	details, err = C.GetSSOUser(ctx, details.ID)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, details)
 
-	details1, err := C.GetSSOUserByFilters("username", "IntegrationTestSSOUser")
+	details1, err := C.GetSSOUserByFilters(ctx, "username", "IntegrationTestSSOUser")
 	assert.Nil(t, err)
 	assert.NotEmpty(t, details1)
 
-	details, err = C.ModifySSOUser(details.ID, &types.SSOUserModifyParam{
+	details, err = C.ModifySSOUser(ctx, details.ID, &types.SSOUserModifyParam{
 		Role: "Technician",
 	})
 	assert.Nil(t, err)
 	assert.NotEmpty(t, details)
 
-	err = C.ResetSSOUserPassword(details.ID, &types.SSOUserModifyParam{Password: "Ssouser1234#"})
+	err = C.ResetSSOUserPassword(ctx, details.ID, &types.SSOUserModifyParam{Password: "Ssouser1234#"})
 	assert.Nil(t, err)
 
-	err = C.DeleteSSOUser(details.ID)
+	err = C.DeleteSSOUser(ctx, details.ID)
 	assert.Nil(t, err)
 }

--- a/inttests/system_limit_test.go
+++ b/inttests/system_limit_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -21,7 +22,7 @@ import (
 
 // TestGetSystemLimits gets the list of system limits
 func TestGetSystemLimits(t *testing.T) {
-	resp, err := C.GetSystemLimits()
+	resp, err := C.GetSystemLimits(context.Background())
 	fmt.Println("systemlimit", resp)
 	assert.NotNil(t, resp)
 	assert.Nil(t, err)
@@ -29,7 +30,7 @@ func TestGetSystemLimits(t *testing.T) {
 
 // TestGetMaxVol get the max volume
 func TestGetMaxVol(t *testing.T) {
-	maxvolsize, err := C.GetMaxVol()
+	maxvolsize, err := C.GetMaxVol(context.Background())
 	fmt.Println("max vol size", maxvolsize)
 	assert.NotNil(t, maxvolsize)
 	assert.Nil(t, err)

--- a/inttests/system_test.go
+++ b/inttests/system_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -24,11 +25,13 @@ import (
 // get the system, this code does not check errors as it is a simple helper
 // and there are specific tests got querying the Systems
 func getSystem() *goscaleio.System {
+	ctx := context.Background()
+
 	// first, get all of the systems
-	allSystems, _ := C.GetSystems()
+	allSystems, _ := C.GetSystems(ctx)
 
 	// then try to get the first one returned, explicitly
-	system, _ := C.FindSystem(allSystems[0].ID, "", "")
+	system, _ := C.FindSystem(ctx, allSystems[0].ID, "", "")
 
 	return system
 }
@@ -36,19 +39,21 @@ func getSystem() *goscaleio.System {
 // TestGetSystems will detect all of the PowerFlex systems connected to this Gateway
 // There should be EXACTLY ONE system, as two/more is not supported
 func TestGetSystems(t *testing.T) {
-	allSystems, err := C.GetSystems()
+	allSystems, err := C.GetSystems(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(allSystems))
 }
 
 // TestGetSystem will search the systems for a specific one
 func TestGetSingleSystemID(t *testing.T) {
+	ctx := context.Background()
+
 	// first, get all of the systems
-	allSystems, err := C.GetSystems()
+	allSystems, err := C.GetSystems(ctx)
 	assert.Nil(t, err)
 
 	// then try to get the first one returned, explicitly
-	system, err := C.FindSystem(allSystems[0].ID, "", "")
+	system, err := C.FindSystem(ctx, allSystems[0].ID, "", "")
 	assert.Nil(t, err)
 	assert.Equal(t, allSystems[0].ID, system.System.ID)
 }
@@ -56,7 +61,7 @@ func TestGetSingleSystemID(t *testing.T) {
 // TestGetSingleSystemByIDInvalid will search the for a system that will not be found
 func TestGetSingleSystemByIDInvalid(t *testing.T) {
 	// then try to get the first one returned, explicitly
-	system, err := C.FindSystem(invalidIdentifier, "", "")
+	system, err := C.FindSystem(context.Background(), invalidIdentifier, "", "")
 	fmt.Printf("system %v err %s\n", system, err)
 	assert.NotNil(t, err)
 	assert.Nil(t, system)
@@ -65,65 +70,73 @@ func TestGetSingleSystemByIDInvalid(t *testing.T) {
 // TestGetSingleSystemByNameInvalid will search the for a system that will not be found
 func TestGetSingleSystemByIDName(t *testing.T) {
 	// then try to get the first one returned, explicitly
-	system, err := C.FindSystem("", invalidIdentifier, "")
+	system, err := C.FindSystem(context.Background(), "", invalidIdentifier, "")
 	assert.NotNil(t, err)
 	assert.Nil(t, system)
 }
 
 // TestGetSystemStatistics will return System statistics
 func TestGetSystemStatistics(t *testing.T) {
+	ctx := context.Background()
+
 	// first, get all of the systems
-	allSystems, err := C.GetSystems()
+	allSystems, err := C.GetSystems(ctx)
 	assert.Nil(t, err)
 
 	// then try to get the first one returned, explicitly
-	system, err := C.FindSystem(allSystems[0].ID, "", "")
+	system, err := C.FindSystem(ctx, allSystems[0].ID, "", "")
 	assert.Nil(t, err)
 	assert.Equal(t, allSystems[0].ID, system.System.ID)
 
-	stats, err := system.GetStatistics()
+	stats, err := system.GetStatistics(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, stats)
 }
 
 // TestGetMDMClusterDetails will return MDM cluster details
 func TestGetMDMClusterDetails(t *testing.T) {
+	ctx := context.Background()
+
 	// first, get all of the systems
-	allSystems, err := C.GetSystems()
+	allSystems, err := C.GetSystems(ctx)
 	assert.Nil(t, err)
 
 	// then try to get the first one returned, explicitly
-	system, err := C.FindSystem(allSystems[0].ID, "", "")
+	system, err := C.FindSystem(ctx, allSystems[0].ID, "", "")
 	assert.Nil(t, err)
 	assert.Equal(t, allSystems[0].ID, system.System.ID)
 
-	mdmDetails, err := system.GetMDMClusterDetails()
+	mdmDetails, err := system.GetMDMClusterDetails(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, mdmDetails)
 }
 
 // TestMDMClusterPerformanceProfile modifies MDM cluster performace profile
 func TestMDMClusterPerformanceProfileInvalid(t *testing.T) {
+	ctx := context.Background()
+
 	// first, get all of the systems
-	allSystems, err := C.GetSystems()
+	allSystems, err := C.GetSystems(ctx)
 	assert.Nil(t, err)
 
 	// then try to get the first one returned, explicitly
-	system, err := C.FindSystem(allSystems[0].ID, "", "")
+	system, err := C.FindSystem(ctx, allSystems[0].ID, "", "")
 	assert.Nil(t, err)
 	assert.Equal(t, allSystems[0].ID, system.System.ID)
 
-	err = system.ModifyPerformanceProfileMdmCluster("High")
+	err = system.ModifyPerformanceProfileMdmCluster(ctx, "High")
 	assert.NotNil(t, err)
 }
 
 // TestAddStandByMDMInvalid attempts to add invalid standby MDM, results in failure
 func TestAddStandByMDMInvalid(t *testing.T) {
-	allSystems, err := C.GetSystems()
+	ctx := context.Background()
+
+	allSystems, err := C.GetSystems(ctx)
 	assert.Nil(t, err)
 
 	// then try to get the first one returned, explicitly
-	system, err := C.FindSystem(allSystems[0].ID, "", "")
+	system, err := C.FindSystem(ctx, allSystems[0].ID, "", "")
 	assert.Nil(t, err)
 	assert.Equal(t, allSystems[0].ID, system.System.ID)
 
@@ -132,41 +145,45 @@ func TestAddStandByMDMInvalid(t *testing.T) {
 		Role: "Manager",
 	}
 
-	_, err1 := system.AddStandByMdm(&payload)
+	_, err1 := system.AddStandByMdm(ctx, &payload)
 	assert.NotNil(t, err1)
 }
 
 // TestRemoveStandByMDMInvalid attempts to remove invalid standby MDM, results in failure
 func TestRemoveStandByMDMInvalid(t *testing.T) {
-	allSystems, err := C.GetSystems()
+	ctx := context.Background()
+
+	allSystems, err := C.GetSystems(ctx)
 	assert.Nil(t, err)
 
 	// then try to get the first one returned, explicitly
-	system, err := C.FindSystem(allSystems[0].ID, "", "")
+	system, err := C.FindSystem(ctx, allSystems[0].ID, "", "")
 	assert.Nil(t, err)
 	assert.Equal(t, allSystems[0].ID, system.System.ID)
 
-	mdmDetails, err1 := system.GetMDMClusterDetails()
+	mdmDetails, err1 := system.GetMDMClusterDetails(ctx)
 	assert.Nil(t, err1)
 	assert.NotNil(t, mdmDetails)
 
 	if len(mdmDetails.StandByMdm) > 0 {
-		err = system.RemoveStandByMdm(mdmDetails.StandByMdm[0].ID)
+		err = system.RemoveStandByMdm(ctx, mdmDetails.StandByMdm[0].ID)
 		assert.Nil(t, err)
 	}
 }
 
 // TestSwitchClusterModeInvalid attempts to switch cluster mode with invalid mode
 func TestSwitchClusterModeInvalid(t *testing.T) {
-	allSystems, err := C.GetSystems()
+	ctx := context.Background()
+
+	allSystems, err := C.GetSystems(ctx)
 	assert.Nil(t, err)
 
 	// then try to get the first one returned, explicitly
-	system, err := C.FindSystem(allSystems[0].ID, "", "")
+	system, err := C.FindSystem(ctx, allSystems[0].ID, "", "")
 	assert.Nil(t, err)
 	assert.Equal(t, allSystems[0].ID, system.System.ID)
 
-	mdmDetails, err1 := system.GetMDMClusterDetails()
+	mdmDetails, err1 := system.GetMDMClusterDetails(ctx)
 	assert.Nil(t, err1)
 	assert.NotNil(t, mdmDetails)
 
@@ -175,21 +192,23 @@ func TestSwitchClusterModeInvalid(t *testing.T) {
 		AddSecondaryMdms: []string{"invalid"},
 	}
 
-	err = system.SwitchClusterMode(&payload)
+	err = system.SwitchClusterMode(ctx, &payload)
 	assert.NotNil(t, err)
 }
 
 // TestRenameMdm modifies MDM name
 func TestRenameMdm(t *testing.T) {
+	ctx := context.Background()
+
 	// first, get all of the systems
-	allSystems, err := C.GetSystems()
+	allSystems, err := C.GetSystems(ctx)
 	assert.Nil(t, err)
 
 	// then try to get the first one returned, explicitly
-	system, err := C.FindSystem(allSystems[0].ID, "", "")
+	system, err := C.FindSystem(ctx, allSystems[0].ID, "", "")
 	assert.Nil(t, err)
 
-	mdmDetails, err1 := system.GetMDMClusterDetails()
+	mdmDetails, err1 := system.GetMDMClusterDetails(ctx)
 	assert.Nil(t, err1)
 	assert.NotNil(t, mdmDetails)
 
@@ -198,7 +217,7 @@ func TestRenameMdm(t *testing.T) {
 		NewName: "mdm_renamed",
 	}
 
-	err = system.RenameMdm(&payload)
+	err = system.RenameMdm(ctx, &payload)
 	assert.Nil(t, err)
 
 	payload = types.RenameMdm{
@@ -206,7 +225,7 @@ func TestRenameMdm(t *testing.T) {
 		NewName: "mdm_renamed",
 	}
 
-	err = system.RenameMdm(&payload)
+	err = system.RenameMdm(ctx, &payload)
 	assert.NotNil(t, err)
 
 	payload = types.RenameMdm{
@@ -214,25 +233,27 @@ func TestRenameMdm(t *testing.T) {
 		NewName: "tb_mdm",
 	}
 
-	err = system.RenameMdm(&payload)
+	err = system.RenameMdm(ctx, &payload)
 	assert.Nil(t, err)
 }
 
 // TestChangeMDMOwnership modifies primary MDM
 func TestChangeMDMOwnership(t *testing.T) {
+	ctx := context.Background()
+
 	// first, get all of the systems
-	allSystems, err := C.GetSystems()
+	allSystems, err := C.GetSystems(ctx)
 	assert.Nil(t, err)
 
 	// then try to get the first one returned, explicitly
-	system, err := C.FindSystem(allSystems[0].ID, "", "")
+	system, err := C.FindSystem(ctx, allSystems[0].ID, "", "")
 	assert.Nil(t, err)
 	assert.Equal(t, allSystems[0].ID, system.System.ID)
 
-	mdmDetails, err1 := system.GetMDMClusterDetails()
+	mdmDetails, err1 := system.GetMDMClusterDetails(ctx)
 	assert.Nil(t, err1)
 	assert.NotNil(t, mdmDetails)
 
-	err = system.ChangeMdmOwnerShip(mdmDetails.SecondaryMDM[0].ID)
+	err = system.ChangeMdmOwnerShip(ctx, mdmDetails.SecondaryMDM[0].ID)
 	assert.Nil(t, err)
 }

--- a/inttests/user_test.go
+++ b/inttests/user_test.go
@@ -13,6 +13,7 @@
 package inttests
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -25,12 +26,14 @@ func TestGetAllUsers(t *testing.T) {
 	system := getSystem()
 	assert.NotNil(t, system)
 
-	allUsers, err := system.GetUser()
+	allUsers, err := system.GetUser(context.Background())
 	assert.Nil(t, err)
 	assert.NotZero(t, len(allUsers))
 }
 
 func TestCreateAndDeleteUser(t *testing.T) {
+	ctx := context.Background()
+
 	// Get the System
 	system := getSystem()
 	assert.NotNil(t, system)
@@ -41,17 +44,17 @@ func TestCreateAndDeleteUser(t *testing.T) {
 		Password: os.Getenv("USER_PASSWORD"),
 		UserRole: "Security",
 	}
-	resp, err1 := system.CreateUser(&userParams)
+	resp, err1 := system.CreateUser(ctx, &userParams)
 	assert.Nil(t, err1)
 	assert.NotEmpty(t, resp)
 
 	// Fetch the User which you just now created
-	user, err2 := system.GetUserByIDName(resp.ID, "")
+	user, err2 := system.GetUserByIDName(ctx, resp.ID, "")
 	assert.Nil(t, err2)
 	assert.Equal(t, "testUser", user.Name)
 	assert.Equal(t, "Security", user.UserRole)
 
-	user2, err2 := system.GetUserByIDName("", "testUser")
+	user2, err2 := system.GetUserByIDName(ctx, "", "testUser")
 	assert.Nil(t, err2)
 	assert.Equal(t, "testUser", user2.Name)
 	assert.Equal(t, "Security", user2.UserRole)
@@ -59,10 +62,10 @@ func TestCreateAndDeleteUser(t *testing.T) {
 	userRoleParams := siotypes.UserRoleParam{
 		UserRole: "Configure",
 	}
-	err3 := system.SetUserRole(&userRoleParams, resp.ID)
+	err3 := system.SetUserRole(ctx, &userRoleParams, resp.ID)
 	assert.Nil(t, err3)
 
 	// Remove the user
-	err4 := system.RemoveUser(resp.ID)
+	err4 := system.RemoveUser(ctx, resp.ID)
 	assert.Nil(t, err4)
 }

--- a/inttests/vtree_test.go
+++ b/inttests/vtree_test.go
@@ -1,55 +1,62 @@
 package inttests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetVTrees(t *testing.T) {
-	allVTrees, err := C.GetVTrees()
+	allVTrees, err := C.GetVTrees(context.Background())
 	assert.Nil(t, err)
 	assert.NotNil(t, allVTrees)
 }
 
 func TestGetVTreeByID(t *testing.T) {
-	allVTrees, err := C.GetVTrees()
+	ctx := context.Background()
+
+	allVTrees, err := C.GetVTrees(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, allVTrees)
 
-	vTree, err := C.GetVTreeByID(allVTrees[0].ID)
+	vTree, err := C.GetVTreeByID(ctx, allVTrees[0].ID)
 	assert.Nil(t, err)
 	assert.NotNil(t, vTree)
 
-	vTree, err = C.GetVTreeByID(invalidIdentifier)
+	vTree, err = C.GetVTreeByID(ctx, invalidIdentifier)
 	assert.NotNil(t, err)
 	assert.Nil(t, vTree)
 }
 
 func TestGetVTreeInstances(t *testing.T) {
-	allVTrees, err := C.GetVTrees()
+	ctx := context.Background()
+
+	allVTrees, err := C.GetVTrees(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, allVTrees)
 
-	allVTrees, err = C.GetVTreeInstances([]string{allVTrees[0].ID})
+	allVTrees, err = C.GetVTreeInstances(ctx, []string{allVTrees[0].ID})
 	assert.Nil(t, err)
 	assert.NotNil(t, allVTrees)
 
-	allVTrees, err = C.GetVTreeInstances([]string{invalidIdentifier})
+	allVTrees, err = C.GetVTreeInstances(ctx, []string{invalidIdentifier})
 	assert.NotNil(t, err)
 	assert.Nil(t, allVTrees)
 }
 
 func TestGetVTreeByVolumeID(t *testing.T) {
-	allVTrees, err := C.GetVTrees()
+	ctx := context.Background()
+
+	allVTrees, err := C.GetVTrees(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, allVTrees)
 
-	vTree, err := C.GetVTreeByVolumeID(allVTrees[0].RootVolumes[0])
+	vTree, err := C.GetVTreeByVolumeID(ctx, allVTrees[0].RootVolumes[0])
 	assert.Nil(t, err)
 	assert.NotNil(t, vTree)
 
-	vTree, err = C.GetVTreeByVolumeID(invalidIdentifier)
+	vTree, err = C.GetVTreeByVolumeID(ctx, invalidIdentifier)
 	assert.NotNil(t, err)
 	assert.Nil(t, vTree)
 }

--- a/lcm.go
+++ b/lcm.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -26,10 +27,10 @@ import (
 // Returns -1 if PFMP version < the given version,
 // Returns 1 if PFMP version > the given version,
 // Returns 0 if PFMP version == the given version.
-func CheckPfmpVersion(client *Client, version string) (int, error) {
+func CheckPfmpVersion(ctx context.Context, client *Client, version string) (int, error) {
 	defer TimeSpent("CheckPfmpVersion", time.Now())
 
-	lcmStatus, err := GetPfmpStatus(*client)
+	lcmStatus, err := GetPfmpStatus(ctx, *client)
 	if err != nil {
 		return -1, fmt.Errorf("failed to get PFMP version : %v", err)
 	}
@@ -42,14 +43,13 @@ func CheckPfmpVersion(client *Client, version string) (int, error) {
 }
 
 // GetPfmpStatus gets the PFMP status
-func GetPfmpStatus(client Client) (*types.LcmStatus, error) {
+func GetPfmpStatus(ctx context.Context, client Client) (*types.LcmStatus, error) {
 	defer TimeSpent("GetPfmpStatus", time.Now())
 
 	path := "/Api/V1/corelcm/status"
 
 	var status types.LcmStatus
-	err := client.getJSONWithRetry(
-		http.MethodGet, path, nil, &status)
+	err := client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &status)
 	if err != nil {
 		return nil, err
 	}

--- a/lcm_test.go
+++ b/lcm_test.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -139,7 +140,7 @@ func Test_CheckPfmpVersion(t *testing.T) {
 			defer server.Close()
 
 			client, _ := NewClientWithArgs(server.URL, "", math.MaxInt64, true, false)
-			result, err := CheckPfmpVersion(client, version)
+			result, err := CheckPfmpVersion(context.Background(), client, version)
 
 			for _, checkFn := range checkFns {
 				checkFn(t, result, err)

--- a/nfs.go
+++ b/nfs.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -22,7 +23,7 @@ import (
 )
 
 // GetFileInterface gets a FileInterface by id
-func (s *System) GetFileInterface(id string) (*types.FileInterface, error) {
+func (s *System) GetFileInterface(ctx context.Context, id string) (*types.FileInterface, error) {
 	if id == "" {
 		return nil, errors.New("id is mandatory, please enter a valid value")
 	}
@@ -30,8 +31,7 @@ func (s *System) GetFileInterface(id string) (*types.FileInterface, error) {
 
 	var resp *types.FileInterface
 
-	err := s.client.getJSONWithRetry(
-		http.MethodGet, path, nil, &resp)
+	err := s.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &resp)
 	if err != nil {
 		return nil, errors.New("could not find the File interface using id")
 	}
@@ -40,7 +40,7 @@ func (s *System) GetFileInterface(id string) (*types.FileInterface, error) {
 }
 
 // GetNASByIDName gets a NAS server by name or ID
-func (s *System) GetNASByIDName(id string, name string) (*types.NAS, error) {
+func (s *System) GetNASByIDName(ctx context.Context, id string, name string) (*types.NAS, error) {
 	var nasList []types.NAS
 
 	if name == "" && id == "" {
@@ -52,8 +52,7 @@ func (s *System) GetNASByIDName(id string, name string) (*types.NAS, error) {
 		path := fmt.Sprintf("/rest/v1/nas-servers/%s?select=*", id)
 
 		var resp *types.NAS
-		err := s.client.getJSONWithRetry(
-			http.MethodGet, path, nil, &resp)
+		err := s.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &resp)
 		if err != nil {
 			return nil, errors.New("could not find NAS server by id")
 		}
@@ -63,8 +62,7 @@ func (s *System) GetNASByIDName(id string, name string) (*types.NAS, error) {
 
 	// Get NAS server by name
 	path := "/rest/v1/nas-servers?select=*"
-	err := s.client.getJSONWithRetry(
-		http.MethodGet, path, nil, &nasList)
+	err := s.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &nasList)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +78,7 @@ func (s *System) GetNASByIDName(id string, name string) (*types.NAS, error) {
 }
 
 // CreateNAS creates a NAS server
-func (s *System) CreateNAS(name string, protectionDomainID string) (*types.CreateNASResponse, error) {
+func (s *System) CreateNAS(ctx context.Context, name string, protectionDomainID string) (*types.CreateNASResponse, error) {
 	var resp types.CreateNASResponse
 
 	path := "/rest/v1/nas-servers"
@@ -90,7 +88,7 @@ func (s *System) CreateNAS(name string, protectionDomainID string) (*types.Creat
 		ProtectionDomainID: protectionDomainID,
 	}
 
-	err := s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)
+	err := s.client.getJSONWithRetry(ctx, http.MethodPost, path, body, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -99,10 +97,10 @@ func (s *System) CreateNAS(name string, protectionDomainID string) (*types.Creat
 }
 
 // DeleteNAS deletes a NAS server
-func (s *System) DeleteNAS(id string) error {
+func (s *System) DeleteNAS(ctx context.Context, id string) error {
 	path := fmt.Sprintf("/rest/v1/nas-servers/%s", id)
 
-	err := s.client.getJSONWithRetry(http.MethodDelete, path, nil, nil)
+	err := s.client.getJSONWithRetry(ctx, http.MethodDelete, path, nil, nil)
 	if err != nil {
 		fmt.Println("err", err)
 		return err
@@ -112,14 +110,14 @@ func (s *System) DeleteNAS(id string) error {
 }
 
 // PingNAS pings a NAS server
-func (s *System) PingNAS(id string, ipaddress string) error {
+func (s *System) PingNAS(ctx context.Context, id string, ipaddress string) error {
 	path := fmt.Sprintf("rest/v1/nas-servers/%s/ping", id)
 	body := types.PingNASParam{
 		DestinationAddress: ipaddress,
 		IsIPV6:             false,
 	}
 
-	err := s.client.getJSONWithRetry(http.MethodPost, path, body, nil)
+	err := s.client.getJSONWithRetry(ctx, http.MethodPost, path, body, nil)
 	if err != nil {
 		return errors.New("Could not ping NAS server " + id)
 	}

--- a/nfs_export.go
+++ b/nfs_export.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -22,12 +23,11 @@ import (
 )
 
 // GetNFSExport lists NFS Exports.
-func (c *Client) GetNFSExport() (nfsList []types.NFSExport, err error) {
+func (c *Client) GetNFSExport(ctx context.Context) (nfsList []types.NFSExport, err error) {
 	defer TimeSpent("GetNfsExport", time.Now())
 	path := "/rest/v1/nfs-exports?select=*"
 
-	err = c.getJSONWithRetry(
-		http.MethodGet, path, nil, &nfsList)
+	err = c.getJSONWithRetry(ctx, http.MethodGet, path, nil, &nfsList)
 	if err != nil {
 		return nil, err
 	}
@@ -36,11 +36,11 @@ func (c *Client) GetNFSExport() (nfsList []types.NFSExport, err error) {
 }
 
 // CreateNFSExport create an NFS Export for a File System.
-func (c *Client) CreateNFSExport(createParams *types.NFSExportCreate) (respnfs *types.NFSExportCreateResponse, err error) {
+func (c *Client) CreateNFSExport(ctx context.Context, createParams *types.NFSExportCreate) (respnfs *types.NFSExportCreateResponse, err error) {
 	path := "/rest/v1/nfs-exports"
 
 	var body *types.NFSExportCreate = createParams
-	err = c.getJSONWithRetry(http.MethodPost, path, body, &respnfs)
+	err = c.getJSONWithRetry(ctx, http.MethodPost, path, body, &respnfs)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (c *Client) CreateNFSExport(createParams *types.NFSExportCreate) (respnfs *
 }
 
 // GetNFSExportByIDName returns NFS Export properties by name or ID
-func (c *Client) GetNFSExportByIDName(id string, name string) (respnfs *types.NFSExport, err error) {
+func (c *Client) GetNFSExportByIDName(ctx context.Context, id string, name string) (respnfs *types.NFSExport, err error) {
 	defer TimeSpent("GetNFSExportByIDName", time.Now())
 
 	if id == "" && name == "" {
@@ -60,8 +60,7 @@ func (c *Client) GetNFSExportByIDName(id string, name string) (respnfs *types.NF
 	if id != "" {
 		path := fmt.Sprintf("/rest/v1/nfs-exports/%s?select=*", id)
 
-		err = c.getJSONWithRetry(
-			http.MethodGet, path, nil, &respnfs)
+		err = c.getJSONWithRetry(ctx, http.MethodGet, path, nil, &respnfs)
 		if err != nil {
 			return nil, errors.New("couldn't find NFS export by ID")
 		}
@@ -70,7 +69,7 @@ func (c *Client) GetNFSExportByIDName(id string, name string) (respnfs *types.NF
 	}
 
 	//	Get NFS export by name
-	nfsList, err := c.GetNFSExport()
+	nfsList, err := c.GetNFSExport(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -85,12 +84,11 @@ func (c *Client) GetNFSExportByIDName(id string, name string) (respnfs *types.NF
 }
 
 // DeleteNFSExport deletes the NFS export
-func (c *Client) DeleteNFSExport(id string) error {
+func (c *Client) DeleteNFSExport(ctx context.Context, id string) error {
 	defer TimeSpent("DeleteNFSExport", time.Now())
 	path := fmt.Sprintf("/rest/v1/nfs-exports/%s", id)
 
-	err := c.getJSONWithRetry(
-		http.MethodDelete, path, nil, nil)
+	err := c.getJSONWithRetry(ctx, http.MethodDelete, path, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -99,11 +97,11 @@ func (c *Client) DeleteNFSExport(id string) error {
 }
 
 // ModifyNFSExport modifies the NFS export properties
-func (c *Client) ModifyNFSExport(ModifyParams *types.NFSExportModify, id string) (err error) {
+func (c *Client) ModifyNFSExport(ctx context.Context, ModifyParams *types.NFSExportModify, id string) (err error) {
 	path := fmt.Sprintf("/rest/v1/nfs-exports/%s", id)
 
 	var body *types.NFSExportModify = ModifyParams
-	err = c.getJSONWithRetry(http.MethodPatch, path, body, nil)
+	err = c.getJSONWithRetry(ctx, http.MethodPatch, path, body, nil)
 	if err != nil {
 		return err
 	}

--- a/nfs_export_test.go
+++ b/nfs_export_test.go
@@ -19,6 +19,7 @@
 package goscaleio
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -195,7 +196,7 @@ func TestGetNFSExportByIDName(t *testing.T) {
 				client: client,
 			}
 
-			resp, err := s.client.GetNFSExportByIDName("", testCaseFSNames[name])
+			resp, err := s.client.GetNFSExportByIDName(context.Background(), "", testCaseFSNames[name])
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -217,7 +218,7 @@ func TestGetNFSExportByIDName(t *testing.T) {
 				client: client,
 			}
 
-			resp, err := s.client.GetNFSExportByIDName(testCaseFSIds[id], "")
+			resp, err := s.client.GetNFSExportByIDName(context.Background(), testCaseFSIds[id], "")
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -240,7 +241,7 @@ func TestDeleteNFSExport(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = client.DeleteNFSExport(id)
+	err = client.DeleteNFSExport(context.Background(), id)
 	assert.Nil(t, err)
 }
 
@@ -320,7 +321,7 @@ func TestCreateNFSExport(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			resp, err := client.CreateNFSExport(&types.NFSExportCreate{
+			resp, err := client.CreateNFSExport(context.Background(), &types.NFSExportCreate{
 				Name:         "twee-kk",
 				FileSystemID: "6436aa58-e6a1-a4e2-de7b-2a50fb1ccff3",
 				Path:         "/twee-fs11",

--- a/nfs_test.go
+++ b/nfs_test.go
@@ -19,6 +19,7 @@
 package goscaleio
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -216,7 +217,7 @@ func TestGetNasByIDName(t *testing.T) {
 				System: system,
 			}
 
-			resp, err := s.GetNASByIDName("", testCaseNasNames[name])
+			resp, err := s.GetNASByIDName(context.Background(), "", testCaseNasNames[name])
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -239,7 +240,7 @@ func TestGetNasByIDName(t *testing.T) {
 				System: system,
 			}
 
-			resp, err := s.GetNASByIDName(testCaseNasIDs[name], "")
+			resp, err := s.GetNASByIDName(context.Background(), testCaseNasIDs[name], "")
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -336,7 +337,7 @@ func TestCreateNAS(t *testing.T) {
 				System: system,
 			}
 
-			resp, err := s.CreateNAS("test-nas1", "pd1")
+			resp, err := s.CreateNAS(context.Background(), "test-nas1", "pd1")
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -369,7 +370,7 @@ func TestDeleteNAS(t *testing.T) {
 		System: system1,
 	}
 
-	err = s.DeleteNAS(id)
+	err = s.DeleteNAS(context.Background(), id)
 	assert.Nil(t, err)
 }
 
@@ -451,7 +452,7 @@ func TestPingNAS(t *testing.T) {
 				System: system,
 			}
 
-			err = s.PingNAS(testCaseNasServers[name][0], testCaseNasServers[name][1])
+			err = s.PingNAS(context.Background(), testCaseNasServers[name][0], testCaseNasServers[name][1])
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
 			}
@@ -556,7 +557,7 @@ func TestGeFileInterfaace(t *testing.T) {
 				System: system,
 			}
 
-			resp, err := s.GetFileInterface(testCaseFileInterfaceIDs[name])
+			resp, err := s.GetFileInterface(context.Background(), testCaseFileInterfaceIDs[name])
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}

--- a/nvme_host.go
+++ b/nvme_host.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -35,15 +36,14 @@ func NewNvmeHost(client *Client, nvmeHost *types.NvmeHost) *NvmeHost {
 }
 
 // GetAllNvmeHosts returns all NvmeHost list
-func (s *System) GetAllNvmeHosts() ([]types.NvmeHost, error) {
+func (s *System) GetAllNvmeHosts(ctx context.Context) ([]types.NvmeHost, error) {
 	defer TimeSpent("GetAllNvmeHosts", time.Now())
 
 	path := fmt.Sprintf("/api/instances/System::%v/relationships/Sdc",
 		s.System.ID)
 
 	var allHosts []types.NvmeHost
-	err := s.client.getJSONWithRetry(
-		http.MethodGet, path, nil, &allHosts)
+	err := s.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &allHosts)
 	if err != nil {
 		return nil, err
 	}
@@ -59,13 +59,13 @@ func (s *System) GetAllNvmeHosts() ([]types.NvmeHost, error) {
 }
 
 // GetNvmeHostByID returns an NVMe host searched by id
-func (s *System) GetNvmeHostByID(id string) (*types.NvmeHost, error) {
+func (s *System) GetNvmeHostByID(ctx context.Context, id string) (*types.NvmeHost, error) {
 	defer TimeSpent("GetNvmeHostByID", time.Now())
 
 	path := fmt.Sprintf("api/instances/Sdc::%v", id)
 
 	var nvmeHost types.NvmeHost
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &nvmeHost)
 	if err != nil {
 		return nil, err
@@ -75,13 +75,13 @@ func (s *System) GetNvmeHostByID(id string) (*types.NvmeHost, error) {
 }
 
 // CreateNvmeHost creates a new NVMe host
-func (s *System) CreateNvmeHost(nvmeHostParam types.NvmeHostParam) (*types.NvmeHostResp, error) {
+func (s *System) CreateNvmeHost(ctx context.Context, nvmeHostParam types.NvmeHostParam) (*types.NvmeHostResp, error) {
 	defer TimeSpent("CreateNvmeHost", time.Now())
 
 	path := "/api/types/Host/instances"
 	nvmeHostResp := &types.NvmeHostResp{}
 
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, nvmeHostParam, nvmeHostResp)
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func (s *System) CreateNvmeHost(nvmeHostParam types.NvmeHostParam) (*types.NvmeH
 }
 
 // ChangeNvmeHostName changes the name of the Nvme host.
-func (s *System) ChangeNvmeHostName(id, name string) error {
+func (s *System) ChangeNvmeHostName(ctx context.Context, id, name string) error {
 	defer TimeSpent("ChangeNvmeHostName", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdc::%v/action/setSdcName", id)
@@ -99,7 +99,7 @@ func (s *System) ChangeNvmeHostName(id, name string) error {
 	body := types.ChangeNvmeHostNameParam{
 		SdcName: name,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, nil)
 	if err != nil {
 		return err
@@ -109,7 +109,7 @@ func (s *System) ChangeNvmeHostName(id, name string) error {
 }
 
 // ChangeNvmeHostMaxNumPaths changes the max number paths of the Nvme host.
-func (s *System) ChangeNvmeHostMaxNumPaths(id string, maxNumPaths int) error {
+func (s *System) ChangeNvmeHostMaxNumPaths(ctx context.Context, id string, maxNumPaths int) error {
 	defer TimeSpent("ChangeNvmeHostMaxNumPaths", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Host::%v/action/modifyMaxNumPaths", id)
@@ -117,7 +117,7 @@ func (s *System) ChangeNvmeHostMaxNumPaths(id string, maxNumPaths int) error {
 	body := types.ChangeNvmeMaxNumPathsParam{
 		MaxNumPaths: types.IntString(maxNumPaths),
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, nil)
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ func (s *System) ChangeNvmeHostMaxNumPaths(id string, maxNumPaths int) error {
 }
 
 // ChangeNvmeHostMaxNumSysPorts changes the max number of sys ports of the Nvme host.
-func (s *System) ChangeNvmeHostMaxNumSysPorts(id string, maxNumSysPorts int) error {
+func (s *System) ChangeNvmeHostMaxNumSysPorts(ctx context.Context, id string, maxNumSysPorts int) error {
 	defer TimeSpent("ChangeNvmeHostMaxNumPaths", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Host::%v/action/modifyMaxNumSysPorts", id)
@@ -135,7 +135,7 @@ func (s *System) ChangeNvmeHostMaxNumSysPorts(id string, maxNumSysPorts int) err
 	body := types.ChangeNvmeHostMaxNumSysPortsParam{
 		MaxNumSysPorts: types.IntString(maxNumSysPorts),
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, nil)
 	if err != nil {
 		return err
@@ -145,13 +145,13 @@ func (s *System) ChangeNvmeHostMaxNumSysPorts(id string, maxNumSysPorts int) err
 }
 
 // DeleteNvmeHost deletes the NVMe host
-func (s *System) DeleteNvmeHost(id string) error {
+func (s *System) DeleteNvmeHost(ctx context.Context, id string) error {
 	defer TimeSpent("DeleteNvmeHost", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdc::%v/action/removeSdc", id)
 
 	param := &types.EmptyPayload{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, param, nil)
 	if err != nil {
 		return err
@@ -160,12 +160,12 @@ func (s *System) DeleteNvmeHost(id string) error {
 }
 
 // GetHostNvmeControllers returns all attached NVMe controllers
-func (s *System) GetHostNvmeControllers(host types.NvmeHost) ([]types.NvmeController, error) {
+func (s *System) GetHostNvmeControllers(ctx context.Context, host types.NvmeHost) ([]types.NvmeController, error) {
 	defer TimeSpent("GetHostNvmeControllers", time.Now())
 	path := fmt.Sprintf("api/instances/Host::%v/relationships/NvmeController", host.ID)
 
 	var nvmeControllers []types.NvmeController
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &nvmeControllers)
 	return nvmeControllers, err
 }

--- a/nvme_host_test.go
+++ b/nvme_host_test.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -138,7 +139,7 @@ func Test_GetAllNvmeHosts(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			nvmeHosts, err := system.GetAllNvmeHosts()
+			nvmeHosts, err := system.GetAllNvmeHosts(context.Background())
 
 			for _, checkFn := range checkFns {
 				checkFn(t, nvmeHosts, err)
@@ -262,7 +263,7 @@ func Test_GetNvmeHostByID(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			nvmeHost, err := system.GetNvmeHostByID("mock-id")
+			nvmeHost, err := system.GetNvmeHostByID(context.Background(), "mock-id")
 
 			for _, checkFn := range checkFns {
 				checkFn(t, nvmeHost, err)
@@ -342,7 +343,7 @@ func Test_CreateNvmeHost(t *testing.T) {
 				MaxNumPaths:    4,
 				MaxNumSysPorts: 10,
 			}
-			resp, err := system.CreateNvmeHost(nvmeHostParam)
+			resp, err := system.CreateNvmeHost(context.Background(), nvmeHostParam)
 
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
@@ -406,7 +407,7 @@ func Test_ChangeNvmeHostName(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.ChangeNvmeHostName("mock-id", "new-mock-name")
+			err := system.ChangeNvmeHostName(context.Background(), "mock-id", "new-mock-name")
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -470,7 +471,7 @@ func Test_ChangeNvmeHostMaxNumPaths(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.ChangeNvmeHostMaxNumPaths("mock-id", 8)
+			err := system.ChangeNvmeHostMaxNumPaths(context.Background(), "mock-id", 8)
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -534,7 +535,7 @@ func Test_ChangeNvmeHostMaxNumSysPorts(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.ChangeNvmeHostMaxNumSysPorts("mock-id", 8)
+			err := system.ChangeNvmeHostMaxNumSysPorts(context.Background(), "mock-id", 8)
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -598,7 +599,7 @@ func Test_DeleteNvmeHost(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.DeleteNvmeHost("mock-id")
+			err := system.DeleteNvmeHost(context.Background(), "mock-id")
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -714,7 +715,7 @@ func Test_GetHostNvmeControllers(t *testing.T) {
 			host := types.NvmeHost{
 				ID: "mock-id",
 			}
-			nvmeHostControllers, err := system.GetHostNvmeControllers(host)
+			nvmeHostControllers, err := system.GetHostNvmeControllers(context.Background(), host)
 
 			for _, checkFn := range checkFns {
 				checkFn(t, nvmeHostControllers, err)

--- a/os_repository.go
+++ b/os_repository.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -23,11 +24,11 @@ import (
 const osRepoPath = "/api/v1/OSRepository"
 
 // GetAllOSRepositories Gets all OS Repositories
-func (s *System) GetAllOSRepositories() ([]types.OSRepository, error) {
+func (s *System) GetAllOSRepositories(ctx context.Context) ([]types.OSRepository, error) {
 	defer TimeSpent("GetAllOSRepositories", time.Now())
 
 	var osRepositories []types.OSRepository
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, osRepoPath, nil, &osRepositories)
 	if err != nil {
 		return nil, err
@@ -36,12 +37,12 @@ func (s *System) GetAllOSRepositories() ([]types.OSRepository, error) {
 }
 
 // GetOSRepositoryByID Gets OS Repository by ID
-func (s *System) GetOSRepositoryByID(id string) (*types.OSRepository, error) {
+func (s *System) GetOSRepositoryByID(ctx context.Context, id string) (*types.OSRepository, error) {
 	defer TimeSpent("GetOSRepositoryByID", time.Now())
 
 	pathWithID := fmt.Sprintf("%v/%v", osRepoPath, id)
 	var osRepository types.OSRepository
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, pathWithID, nil, &osRepository)
 	if err != nil {
 		return nil, err
@@ -51,7 +52,7 @@ func (s *System) GetOSRepositoryByID(id string) (*types.OSRepository, error) {
 }
 
 // CreateOSRepository Creates OS Repository
-func (s *System) CreateOSRepository(createOSRepository *types.OSRepository) (*types.OSRepository, error) {
+func (s *System) CreateOSRepository(ctx context.Context, createOSRepository *types.OSRepository) (*types.OSRepository, error) {
 	defer TimeSpent("CreateOSRepository", time.Now())
 	var createResponse types.OSRepository
 	if createOSRepository == nil {
@@ -63,7 +64,7 @@ func (s *System) CreateOSRepository(createOSRepository *types.OSRepository) (*ty
 		"sourcePath": createOSRepository.SourcePath,
 		"imageType":  createOSRepository.ImageType,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, osRepoPath, bodyData, &createResponse)
 	if err != nil {
 		return nil, err
@@ -73,10 +74,10 @@ func (s *System) CreateOSRepository(createOSRepository *types.OSRepository) (*ty
 }
 
 // RemoveOSRepository Removes OS Repository
-func (s *System) RemoveOSRepository(id string) error {
+func (s *System) RemoveOSRepository(ctx context.Context, id string) error {
 	defer TimeSpent("RemoveOSRepository", time.Now())
 	pathWithID := fmt.Sprintf("%v/%v", osRepoPath, id)
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodDelete, pathWithID, nil, nil)
 	if err != nil {
 		return err

--- a/replication.go
+++ b/replication.go
@@ -18,6 +18,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -51,29 +52,29 @@ func NewPeerMDM(client *Client, peerMDM *types.PeerMDM) *PeerMDM {
 }
 
 // GetPeerMDMs returns a list of peer MDMs know to the System
-func (c *Client) GetPeerMDMs() ([]*types.PeerMDM, error) {
+func (c *Client) GetPeerMDMs(ctx context.Context) ([]*types.PeerMDM, error) {
 	defer TimeSpent("GetPeerMDMs", time.Now())
 
 	path := "/api/types/PeerMdm/instances"
 	var peerMdms []*types.PeerMDM
 
-	err := c.getJSONWithRetry(http.MethodGet, path, nil, &peerMdms)
+	err := c.getJSONWithRetry(ctx, http.MethodGet, path, nil, &peerMdms)
 	return peerMdms, err
 }
 
 // GetPeerMDM returns a specific peer MDM
-func (c *Client) GetPeerMDM(id string) (*types.PeerMDM, error) {
+func (c *Client) GetPeerMDM(ctx context.Context, id string) (*types.PeerMDM, error) {
 	defer TimeSpent("GetPeerMDM", time.Now())
 
 	path := "/api/instances/PeerMdm::" + id
 	var peerMdm *types.PeerMDM
 
-	err := c.getJSONWithRetry(http.MethodGet, path, nil, &peerMdm)
+	err := c.getJSONWithRetry(ctx, http.MethodGet, path, nil, &peerMdm)
 	return peerMdm, err
 }
 
 // ModifyPeerMdmIP updates a Peer MDM Ips
-func (c *Client) ModifyPeerMdmIP(id string, ips []string) error {
+func (c *Client) ModifyPeerMdmIP(ctx context.Context, id string, ips []string) error {
 	defer TimeSpent("ModifyPeerMdmIP", time.Now())
 	// Format into the strucutre that the API expects
 	var ipMap []map[string]interface{}
@@ -85,8 +86,8 @@ func (c *Client) ModifyPeerMdmIP(id string, ips []string) error {
 	}
 	path := "/api/instances/PeerMdm::" + id + "/action/modifyPeerMdmIp"
 
-	if err := c.getJSONWithRetry(http.MethodPost, path, param, nil); err != nil {
-		fmt.Printf("c.getJSONWithRetry(http.MethodPost, path, param, nil) returned %s", err)
+	if err := c.getJSONWithRetry(ctx, http.MethodPost, path, param, nil); err != nil {
+		fmt.Printf("c.getJSONWithRetry(ctx,http.MethodPost, path, param, nil) returned %s", err)
 		return err
 	}
 
@@ -94,13 +95,13 @@ func (c *Client) ModifyPeerMdmIP(id string, ips []string) error {
 }
 
 // ModifyPeerMdmName updates a Peer MDM Name
-func (c *Client) ModifyPeerMdmName(id string, name *types.ModifyPeerMDMNameParam) error {
+func (c *Client) ModifyPeerMdmName(ctx context.Context, id string, name *types.ModifyPeerMDMNameParam) error {
 	defer TimeSpent("ModifyPeerMdmName", time.Now())
 
 	path := "/api/instances/PeerMdm::" + id + "/action/modifyPeerMdmName"
 
-	if err := c.getJSONWithRetry(http.MethodPost, path, name, nil); err != nil {
-		fmt.Printf("c.getJSONWithRetry(http.MethodPost, path, name, nil) returned %s", err)
+	if err := c.getJSONWithRetry(ctx, http.MethodPost, path, name, nil); err != nil {
+		fmt.Printf("c.getJSONWithRetry(ctx,http.MethodPost, path, name, nil) returned %s", err)
 		return err
 	}
 
@@ -108,13 +109,13 @@ func (c *Client) ModifyPeerMdmName(id string, name *types.ModifyPeerMDMNameParam
 }
 
 // ModifyPeerMdmPort updates a Peer MDM Port
-func (c *Client) ModifyPeerMdmPort(id string, port *types.ModifyPeerMDMPortParam) error {
+func (c *Client) ModifyPeerMdmPort(ctx context.Context, id string, port *types.ModifyPeerMDMPortParam) error {
 	defer TimeSpent("ModifyPeerMdmPort", time.Now())
 
 	path := "/api/instances/PeerMdm::" + id + "/action/modifyPeerMdmPort"
 
-	if err := c.getJSONWithRetry(http.MethodPost, path, port, nil); err != nil {
-		fmt.Printf("c.getJSONWithRetry(http.MethodPost, path, port, nil) returned %s", err)
+	if err := c.getJSONWithRetry(ctx, http.MethodPost, path, port, nil); err != nil {
+		fmt.Printf("c.getJSONWithRetry(ctx,http.MethodPost, path, port, nil) returned %s", err)
 		return err
 	}
 
@@ -122,13 +123,13 @@ func (c *Client) ModifyPeerMdmPort(id string, port *types.ModifyPeerMDMPortParam
 }
 
 // ModifyPeerMdmPerformanceParameters updates a Peer MDM Performance Parameters
-func (c *Client) ModifyPeerMdmPerformanceParameters(id string, param *types.ModifyPeerMdmPerformanceParametersParam) error {
+func (c *Client) ModifyPeerMdmPerformanceParameters(ctx context.Context, id string, param *types.ModifyPeerMdmPerformanceParametersParam) error {
 	defer TimeSpent("ModifyPeerMdmPerformanceParameters", time.Now())
 
 	path := "/api/instances/PeerMdm::" + id + "/action/setPeerMdmPerformanceParameters"
 
-	if err := c.getJSONWithRetry(http.MethodPost, path, param, nil); err != nil {
-		fmt.Printf("c.getJSONWithRetry(http.MethodPost, path, param, nil) returned %s", err)
+	if err := c.getJSONWithRetry(ctx, http.MethodPost, path, param, nil); err != nil {
+		fmt.Printf("c.getJSONWithRetry(ctx,http.MethodPost, path, param, nil) returned %s", err)
 		return err
 	}
 
@@ -136,7 +137,7 @@ func (c *Client) ModifyPeerMdmPerformanceParameters(id string, param *types.Modi
 }
 
 // AddPeerMdm Adds a Peer MDM
-func (c *Client) AddPeerMdm(param *types.AddPeerMdm) (*types.PeerMDM, error) {
+func (c *Client) AddPeerMdm(ctx context.Context, param *types.AddPeerMdm) (*types.PeerMDM, error) {
 	defer TimeSpent("AddPeerMdm", time.Now())
 	if param.PeerSystemID == "" || len(param.PeerSystemIps) == 0 {
 		return nil, errors.New("PeerSystemID and PeerSystemIps are required")
@@ -154,8 +155,8 @@ func (c *Client) AddPeerMdm(param *types.AddPeerMdm) (*types.PeerMDM, error) {
 		Name:          param.Name,
 	}
 
-	if err := c.getJSONWithRetry(http.MethodPost, path, paramCreate, peerMdm); err != nil {
-		fmt.Printf("c.getJSONWithRetry(http.MethodPost, path, paramCreate, peerMdm) returned %s", err)
+	if err := c.getJSONWithRetry(ctx, http.MethodPost, path, paramCreate, peerMdm); err != nil {
+		fmt.Printf("c.getJSONWithRetry(ctx,http.MethodPost, path, paramCreate, peerMdm) returned %s", err)
 		return nil, err
 	}
 
@@ -163,13 +164,13 @@ func (c *Client) AddPeerMdm(param *types.AddPeerMdm) (*types.PeerMDM, error) {
 }
 
 // RemovePeerMdm removes a Peer MDM
-func (c *Client) RemovePeerMdm(id string) error {
+func (c *Client) RemovePeerMdm(ctx context.Context, id string) error {
 	defer TimeSpent("RemovePeerMdm", time.Now())
 
 	path := "/api/instances/PeerMdm::" + id + "/action/removePeerMdm"
 	params := types.EmptyPayload{}
-	if err := c.getJSONWithRetry(http.MethodPost, path, params, nil); err != nil {
-		fmt.Printf("c.getJSONWithRetry(http.MethodPost, path, params, nil) returned %s", err)
+	if err := c.getJSONWithRetry(ctx, http.MethodPost, path, params, nil); err != nil {
+		fmt.Printf("c.getJSONWithRetry(ctx,http.MethodPost, path, params, nil) returned %s", err)
 		return err
 	}
 
@@ -207,29 +208,29 @@ func NewReplicationPair(client *Client) *ReplicationPair {
 }
 
 // GetReplicationConsistencyGroups returns a list of the ReplicationConsistencyGroups
-func (c *Client) GetReplicationConsistencyGroups() ([]*types.ReplicationConsistencyGroup, error) {
+func (c *Client) GetReplicationConsistencyGroups(ctx context.Context) ([]*types.ReplicationConsistencyGroup, error) {
 	defer TimeSpent("GetReplicationConsistencyGroups", time.Now())
 
 	uri := "/api/types/ReplicationConsistencyGroup/instances"
 	var rcgs []*types.ReplicationConsistencyGroup
 
-	err := c.getJSONWithRetry(http.MethodGet, uri, nil, &rcgs)
+	err := c.getJSONWithRetry(ctx, http.MethodGet, uri, nil, &rcgs)
 	return rcgs, err
 }
 
 // GetReplicationConsistencyGroupByID returns a specified ReplicationConsistencyGroup
-func (c *Client) GetReplicationConsistencyGroupByID(groupID string) (*types.ReplicationConsistencyGroup, error) {
+func (c *Client) GetReplicationConsistencyGroupByID(ctx context.Context, groupID string) (*types.ReplicationConsistencyGroup, error) {
 	defer TimeSpent("GetReplicationConsistencyGroupById", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + groupID
 	var group *types.ReplicationConsistencyGroup
 
-	err := c.getJSONWithRetry(http.MethodGet, uri, nil, &group)
+	err := c.getJSONWithRetry(ctx, http.MethodGet, uri, nil, &group)
 	return group, err
 }
 
 // CreateReplicationConsistencyGroup creates a ReplicationConsistencyGroup on the array
-func (c *Client) CreateReplicationConsistencyGroup(rcg *types.ReplicationConsistencyGroupCreatePayload) (*types.ReplicationConsistencyGroupResp, error) {
+func (c *Client) CreateReplicationConsistencyGroup(ctx context.Context, rcg *types.ReplicationConsistencyGroupCreatePayload) (*types.ReplicationConsistencyGroupResp, error) {
 	defer TimeSpent("CreateReplicationConsistencyGroup", time.Now())
 
 	if rcg.RpoInSeconds == "" || rcg.ProtectionDomainID == "" || rcg.RemoteProtectionDomainID == "" {
@@ -243,9 +244,9 @@ func (c *Client) CreateReplicationConsistencyGroup(rcg *types.ReplicationConsist
 	path := "/api/types/ReplicationConsistencyGroup/instances"
 	rcgResp := &types.ReplicationConsistencyGroupResp{}
 
-	err := c.getJSONWithRetry(http.MethodPost, path, rcg, rcgResp)
+	err := c.getJSONWithRetry(ctx, http.MethodPost, path, rcg, rcgResp)
 	if err != nil {
-		fmt.Printf("c.getJSONWithRetry(http.MethodPost, path, rcg, rcgResp) returned %s", err)
+		fmt.Printf("c.getJSONWithRetry(ctx,http.MethodPost, path, rcg, rcgResp) returned %s", err)
 		return nil, err
 	}
 	return rcgResp, nil
@@ -253,7 +254,7 @@ func (c *Client) CreateReplicationConsistencyGroup(rcg *types.ReplicationConsist
 
 // RemoveReplicationConsistencyGroup removes a replication consistency group
 // At this point I don't know when forceIgnoreConsistency might be required.
-func (rcg *ReplicationConsistencyGroup) RemoveReplicationConsistencyGroup(forceIgnoreConsistency bool) error {
+func (rcg *ReplicationConsistencyGroup) RemoveReplicationConsistencyGroup(ctx context.Context, forceIgnoreConsistency bool) error {
 	defer TimeSpent("RemoveReplicationConsistencyGroup", time.Now())
 
 	link, err := GetLink(rcg.ReplicationConsistencyGroup.Links, "self")
@@ -267,34 +268,34 @@ func (rcg *ReplicationConsistencyGroup) RemoveReplicationConsistencyGroup(forceI
 		removeRCGParam.ForceIgnoreConsistency = "True"
 	}
 
-	err = rcg.client.getJSONWithRetry(http.MethodPost, path, removeRCGParam, nil)
+	err = rcg.client.getJSONWithRetry(ctx, http.MethodPost, path, removeRCGParam, nil)
 	return err
 }
 
 // FreezeReplicationConsistencyGroup sets the ReplicationConsistencyGroup into a freeze state
-func (rcg *ReplicationConsistencyGroup) FreezeReplicationConsistencyGroup(id string) error {
+func (rcg *ReplicationConsistencyGroup) FreezeReplicationConsistencyGroup(ctx context.Context, id string) error {
 	defer TimeSpent("FreezeReplicationConsistencyGroup", time.Now())
 
 	params := types.EmptyPayload{}
 	path := "/api/instances/ReplicationConsistencyGroup::" + id + "/action/freezeApplyReplicationConsistencyGroup"
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, path, params, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, path, params, nil)
 	return err
 }
 
 // UnfreezeReplicationConsistencyGroup sets the ReplicationConsistencyGroup into a Unfreeze state
-func (rcg *ReplicationConsistencyGroup) UnfreezeReplicationConsistencyGroup() error {
+func (rcg *ReplicationConsistencyGroup) UnfreezeReplicationConsistencyGroup(ctx context.Context) error {
 	defer TimeSpent("UnfreezeReplicationConsistencyGroup", time.Now())
 
 	params := types.EmptyPayload{}
 	path := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/unfreezeApplyReplicationConsistencyGroup"
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, path, params, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, path, params, nil)
 	return err
 }
 
 // CreateReplicationPair creates a ReplicationPair on the desired ReplicaitonConsistencyGroup
-func (c *Client) CreateReplicationPair(rp *types.QueryReplicationPair) (*types.ReplicationPair, error) {
+func (c *Client) CreateReplicationPair(ctx context.Context, rp *types.QueryReplicationPair) (*types.ReplicationPair, error) {
 	defer TimeSpent("CreateReplicationPair", time.Now())
 
 	if rp.CopyType == "" || rp.SourceVolumeID == "" || rp.DestinationVolumeID == "" || rp.ReplicationConsistencyGroupID == "" {
@@ -304,8 +305,8 @@ func (c *Client) CreateReplicationPair(rp *types.QueryReplicationPair) (*types.R
 	path := "/api/types/ReplicationPair/instances"
 	rpResp := &types.ReplicationPair{}
 
-	if err := c.getJSONWithRetry(http.MethodPost, path, rp, rpResp); err != nil {
-		fmt.Printf("c.getJSONWithRetry(http.MethodPost, path, rp, rpResp) returned %s", err)
+	if err := c.getJSONWithRetry(ctx, http.MethodPost, path, rp, rpResp); err != nil {
+		fmt.Printf("c.getJSONWithRetry(ctx,http.MethodPost, path, rp, rpResp) returned %s", err)
 		return nil, err
 	}
 
@@ -313,7 +314,7 @@ func (c *Client) CreateReplicationPair(rp *types.QueryReplicationPair) (*types.R
 }
 
 // RemoveReplicationPair removes the desired replication pair.
-func (rp *ReplicationPair) RemoveReplicationPair(force bool) (*types.ReplicationPair, error) {
+func (rp *ReplicationPair) RemoveReplicationPair(ctx context.Context, force bool) (*types.ReplicationPair, error) {
 	defer TimeSpent("RemoveReplicationPair", time.Now())
 
 	uri := "/api/instances/ReplicationPair::" + rp.ReplicaitonPair.ID + "/action/removeReplicationPair"
@@ -325,8 +326,8 @@ func (rp *ReplicationPair) RemoveReplicationPair(force bool) (*types.Replication
 		param.Force = "true"
 	}
 
-	if err := rp.client.getJSONWithRetry(http.MethodPost, uri, param, resp); err != nil {
-		fmt.Printf("c.getJSONWithRetry(http.MethodPost, path, rp, pair) returned %s", err)
+	if err := rp.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, resp); err != nil {
+		fmt.Printf("c.getJSONWithRetry(ctx,http.MethodPost, path, rp, pair) returned %s", err)
 		return nil, err
 	}
 
@@ -334,130 +335,130 @@ func (rp *ReplicationPair) RemoveReplicationPair(force bool) (*types.Replication
 }
 
 // GetReplicationPairStatistics returns the statistics of the desired ReplicaitonPair.
-func (rp *ReplicationPair) GetReplicationPairStatistics() (*types.QueryReplicationPairStatistics, error) {
+func (rp *ReplicationPair) GetReplicationPairStatistics(ctx context.Context) (*types.QueryReplicationPairStatistics, error) {
 	defer TimeSpent("GetReplicationPairStatistics", time.Now())
 
 	path := "/api/instances/ReplicationPair::" + rp.ReplicaitonPair.ID + "/relationships/Statistics"
 	rpResp := &types.QueryReplicationPairStatistics{}
 
-	err := rp.client.getJSONWithRetry(http.MethodGet, path, nil, &rpResp)
+	err := rp.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &rpResp)
 	return rpResp, err
 }
 
 // GetAllReplicationPairs returns a list all replication pairs on the system.
-func (c *Client) GetAllReplicationPairs() ([]*types.ReplicationPair, error) {
+func (c *Client) GetAllReplicationPairs(ctx context.Context) ([]*types.ReplicationPair, error) {
 	defer TimeSpent("GetReplicationPairs", time.Now())
 
 	path := "/api/types/ReplicationPair/instances"
 
 	var pairs []*types.ReplicationPair
-	err := c.getJSONWithRetry(http.MethodGet, path, nil, &pairs)
+	err := c.getJSONWithRetry(ctx, http.MethodGet, path, nil, &pairs)
 	return pairs, err
 }
 
 // GetReplicationPair returns a specific replication pair on the system.
-func (c *Client) GetReplicationPair(id string) (*types.ReplicationPair, error) {
+func (c *Client) GetReplicationPair(ctx context.Context, id string) (*types.ReplicationPair, error) {
 	defer TimeSpent("GetReplicationPair", time.Now())
 
 	path := "/api/instances/ReplicationPair::" + id
 
 	var pair *types.ReplicationPair
-	err := c.getJSONWithRetry(http.MethodGet, path, nil, &pair)
+	err := c.getJSONWithRetry(ctx, http.MethodGet, path, nil, &pair)
 	return pair, err
 }
 
 // PausePairInitialCopy pauses the initial copy of the replication pair.
-func (c *Client) PausePairInitialCopy(id string) (*types.ReplicationPair, error) {
+func (c *Client) PausePairInitialCopy(ctx context.Context, id string) (*types.ReplicationPair, error) {
 	defer TimeSpent("PausePairInitialCopy", time.Now())
 
 	path := "/api/instances/ReplicationPair::" + id + "/action/pausePairInitialCopy"
 
 	var pair *types.ReplicationPair
-	err := c.getJSONWithRetry(http.MethodPost, path, types.EmptyPayload{}, &pair)
+	err := c.getJSONWithRetry(ctx, http.MethodPost, path, types.EmptyPayload{}, &pair)
 	return pair, err
 }
 
 // ResumePairInitialCopy resumes the initial copy of the replication pair.
-func (c *Client) ResumePairInitialCopy(id string) (*types.ReplicationPair, error) {
+func (c *Client) ResumePairInitialCopy(ctx context.Context, id string) (*types.ReplicationPair, error) {
 	defer TimeSpent("ResumePairInitialCopy", time.Now())
 
 	path := "/api/instances/ReplicationPair::" + id + "/action/resumePairInitialCopy"
 
 	var pair *types.ReplicationPair
-	err := c.getJSONWithRetry(http.MethodPost, path, types.EmptyPayload{}, &pair)
+	err := c.getJSONWithRetry(ctx, http.MethodPost, path, types.EmptyPayload{}, &pair)
 	return pair, err
 }
 
 // GetReplicationPairs returns a list of replication pairs associated to the rcg.
-func (rcg *ReplicationConsistencyGroup) GetReplicationPairs() ([]*types.ReplicationPair, error) {
+func (rcg *ReplicationConsistencyGroup) GetReplicationPairs(ctx context.Context) ([]*types.ReplicationPair, error) {
 	defer TimeSpent("GetReplicationPairs", time.Now())
 
 	path := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/relationships/ReplicationPair"
 
 	var pairs []*types.ReplicationPair
-	err := rcg.client.getJSONWithRetry(http.MethodGet, path, nil, &pairs)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &pairs)
 	return pairs, err
 }
 
 // CreateReplicationConsistencyGroupSnapshot creates a snapshot of the ReplicationConsistencyGroup on the target array.
-func (rcg *ReplicationConsistencyGroup) CreateReplicationConsistencyGroupSnapshot() (*types.CreateReplicationConsistencyGroupSnapshotResp, error) {
+func (rcg *ReplicationConsistencyGroup) CreateReplicationConsistencyGroupSnapshot(ctx context.Context) (*types.CreateReplicationConsistencyGroupSnapshotResp, error) {
 	defer TimeSpent("GetReplicationPairs", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/createReplicationConsistencyGroupSnapshots"
 
 	resp := &types.CreateReplicationConsistencyGroupSnapshotResp{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, types.EmptyPayload{}, resp)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, types.EmptyPayload{}, resp)
 	return resp, err
 }
 
 // ExecuteFailoverOnReplicationGroup sets the ReplicationconsistencyGroup into a failover state.
-func (rcg *ReplicationConsistencyGroup) ExecuteFailoverOnReplicationGroup() error {
+func (rcg *ReplicationConsistencyGroup) ExecuteFailoverOnReplicationGroup(ctx context.Context) error {
 	defer TimeSpent("ExecuteFailoverOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/failoverReplicationConsistencyGroup"
 	param := types.EmptyPayload{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // ExecuteSwitchoverOnReplicationGroup sets the ReplicationconsistencyGroup into a switchover state.
-func (rcg *ReplicationConsistencyGroup) ExecuteSwitchoverOnReplicationGroup(_ bool) error {
+func (rcg *ReplicationConsistencyGroup) ExecuteSwitchoverOnReplicationGroup(ctx context.Context, _ bool) error {
 	defer TimeSpent("ExecuteSwitchoverOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/switchoverReplicationConsistencyGroup"
 	// API is incorrect. No params needed.
 	param := types.EmptyPayload{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // ExecuteRestoreOnReplicationGroup restores the ReplicationConsistencyGroup from a failover/switchover state.
-func (rcg *ReplicationConsistencyGroup) ExecuteRestoreOnReplicationGroup() error {
+func (rcg *ReplicationConsistencyGroup) ExecuteRestoreOnReplicationGroup(ctx context.Context) error {
 	defer TimeSpent("ExecuteRestoreOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/restoreReplicationConsistencyGroup"
 	param := types.EmptyPayload{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // ExecuteReverseOnReplicationGroup reverses the direction of replication from a failover/switchover state.
-func (rcg *ReplicationConsistencyGroup) ExecuteReverseOnReplicationGroup() error {
+func (rcg *ReplicationConsistencyGroup) ExecuteReverseOnReplicationGroup(ctx context.Context) error {
 	defer TimeSpent("ExecuteReverseOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/reverseReplicationConsistencyGroup"
 	param := types.EmptyPayload{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // ExecutePauseOnReplicationGroup pauses the replication of the ConsistencyGroup.
-func (rcg *ReplicationConsistencyGroup) ExecutePauseOnReplicationGroup() error {
+func (rcg *ReplicationConsistencyGroup) ExecutePauseOnReplicationGroup(ctx context.Context) error {
 	defer TimeSpent("ExecutePauseOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/pauseReplicationConsistencyGroup"
@@ -465,109 +466,109 @@ func (rcg *ReplicationConsistencyGroup) ExecutePauseOnReplicationGroup() error {
 		PauseMode: string(types.StopDataTransfer),
 	}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // ExecuteResumeOnReplicationGroup resumes the ConsistencyGroup when it is in a Paused state.
-func (rcg *ReplicationConsistencyGroup) ExecuteResumeOnReplicationGroup() error {
+func (rcg *ReplicationConsistencyGroup) ExecuteResumeOnReplicationGroup(ctx context.Context) error {
 	defer TimeSpent("ExecuteResumeOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/resumeReplicationConsistencyGroup"
 	param := types.EmptyPayload{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // ExecuteSyncOnReplicationGroup forces a synce on the ConsistencyGroup.
-func (rcg *ReplicationConsistencyGroup) ExecuteSyncOnReplicationGroup() (*types.SynchronizationResponse, error) {
+func (rcg *ReplicationConsistencyGroup) ExecuteSyncOnReplicationGroup(ctx context.Context) (*types.SynchronizationResponse, error) {
 	defer TimeSpent("ExecuteSyncOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/syncNowReplicationConsistencyGroup"
 	param := types.EmptyPayload{}
 	resp := &types.SynchronizationResponse{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, resp)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, resp)
 	return resp, err
 }
 
 // SetRPOOnReplicationGroup on the ConsistencyGroup.
-func (rcg *ReplicationConsistencyGroup) SetRPOOnReplicationGroup(param types.SetRPOReplicationConsistencyGroup) error {
+func (rcg *ReplicationConsistencyGroup) SetRPOOnReplicationGroup(ctx context.Context, param types.SetRPOReplicationConsistencyGroup) error {
 	defer TimeSpent("SetRPOOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/ModifyReplicationConsistencyGroupRpo"
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // SetTargetVolumeAccessModeOnReplicationGroup on the ConsistencyGroup.
-func (rcg *ReplicationConsistencyGroup) SetTargetVolumeAccessModeOnReplicationGroup(param types.SetTargetVolumeAccessModeOnReplicationGroup) error {
+func (rcg *ReplicationConsistencyGroup) SetTargetVolumeAccessModeOnReplicationGroup(ctx context.Context, param types.SetTargetVolumeAccessModeOnReplicationGroup) error {
 	defer TimeSpent("SetTargetVolumeAccessModeOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/modifyReplicationConsistencyGroupTargetVolumeAccessMode"
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // SetNewNameOnReplicationGroup on the ConsistencyGroup.
-func (rcg *ReplicationConsistencyGroup) SetNewNameOnReplicationGroup(param types.SetNewNameOnReplicationGroup) error {
+func (rcg *ReplicationConsistencyGroup) SetNewNameOnReplicationGroup(ctx context.Context, param types.SetNewNameOnReplicationGroup) error {
 	defer TimeSpent("SetNewNameOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/renameReplicationConsistencyGroup"
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // ExecuteConsistentOnReplicationGroup on the ConsistencyGroup.
-func (rcg *ReplicationConsistencyGroup) ExecuteConsistentOnReplicationGroup() error {
+func (rcg *ReplicationConsistencyGroup) ExecuteConsistentOnReplicationGroup(ctx context.Context) error {
 	defer TimeSpent("ExecuteConsistentOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/setReplicationConsistencyGroupConsistent"
 	param := types.EmptyPayload{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // ExecuteInconsistentOnReplicationGroup on the ConsistencyGroup.
-func (rcg *ReplicationConsistencyGroup) ExecuteInconsistentOnReplicationGroup() error {
+func (rcg *ReplicationConsistencyGroup) ExecuteInconsistentOnReplicationGroup(ctx context.Context) error {
 	defer TimeSpent("ExecuteInconsistentOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/setReplicationConsistencyGroupInconsistent"
 	param := types.EmptyPayload{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // ExecuteActivateOnReplicationGroup on the ConsistencyGroup.
-func (rcg *ReplicationConsistencyGroup) ExecuteActivateOnReplicationGroup() error {
+func (rcg *ReplicationConsistencyGroup) ExecuteActivateOnReplicationGroup(ctx context.Context) error {
 	defer TimeSpent("ExecuteActivateOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/activateReplicationConsistencyGroup"
 	param := types.EmptyPayload{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // ExecuteTerminateOnReplicationGroup on the ConsistencyGroup.
-func (rcg *ReplicationConsistencyGroup) ExecuteTerminateOnReplicationGroup() error {
+func (rcg *ReplicationConsistencyGroup) ExecuteTerminateOnReplicationGroup(ctx context.Context) error {
 	defer TimeSpent("ExecuteTerminateOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/terminateReplicationConsistencyGroup"
 	param := types.EmptyPayload{}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }
 
 // GetSyncStateOnReplicationGroup returns the sync status of the ReplicaitonConsistencyGroup.
-func (rcg *ReplicationConsistencyGroup) GetSyncStateOnReplicationGroup(syncKey string) error {
+func (rcg *ReplicationConsistencyGroup) GetSyncStateOnReplicationGroup(ctx context.Context, syncKey string) error {
 	defer TimeSpent("ExecuteSyncOnReplicationGroup", time.Now())
 
 	uri := "/api/instances/ReplicationConsistencyGroup::" + rcg.ReplicationConsistencyGroup.ID + "/action/querySyncNowReplicationConsistencyGroup"
@@ -575,6 +576,6 @@ func (rcg *ReplicationConsistencyGroup) GetSyncStateOnReplicationGroup(syncKey s
 		SyncNowKey: syncKey,
 	}
 
-	err := rcg.client.getJSONWithRetry(http.MethodPost, uri, param, nil)
+	err := rcg.client.getJSONWithRetry(ctx, http.MethodPost, uri, param, nil)
 	return err
 }

--- a/scsiinitiator.go
+++ b/scsiinitiator.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -21,7 +22,7 @@ import (
 )
 
 // GetScsiInitiator returns a ScsiInitiator
-func (s *System) GetScsiInitiator() ([]types.ScsiInitiator, error) {
+func (s *System) GetScsiInitiator(ctx context.Context) ([]types.ScsiInitiator, error) {
 	defer TimeSpent("GetScsiInitiator", time.Now())
 
 	path := fmt.Sprintf(
@@ -29,8 +30,7 @@ func (s *System) GetScsiInitiator() ([]types.ScsiInitiator, error) {
 		s.System.ID)
 
 	var si []types.ScsiInitiator
-	err := s.client.getJSONWithRetry(
-		http.MethodGet, path, nil, &si)
+	err := s.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &si)
 	if err != nil {
 		return nil, err
 	}

--- a/sdc.go
+++ b/sdc.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -39,14 +40,14 @@ func NewSdc(client *Client, sdc *types.Sdc) *Sdc {
 }
 
 // GetSdc returns a Sdc
-func (s *System) GetSdc() ([]types.Sdc, error) {
+func (s *System) GetSdc(ctx context.Context) ([]types.Sdc, error) {
 	defer TimeSpent("GetSdc", time.Now())
 
 	path := fmt.Sprintf("/api/instances/System::%v/relationships/Sdc",
 		s.System.ID)
 
 	var sdcs []types.Sdc
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &sdcs)
 	if err != nil {
 		return nil, err
@@ -56,13 +57,13 @@ func (s *System) GetSdc() ([]types.Sdc, error) {
 }
 
 // GetSdcByID returns a Sdc searched by id
-func (s *System) GetSdcByID(id string) (*Sdc, error) {
+func (s *System) GetSdcByID(ctx context.Context, id string) (*Sdc, error) {
 	defer TimeSpent("GetSdcByID", time.Now())
 
 	path := fmt.Sprintf("api/instances/Sdc::%v", id)
 
 	var sdc types.Sdc
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &sdc)
 	if err != nil {
 		return nil, err
@@ -73,7 +74,7 @@ func (s *System) GetSdcByID(id string) (*Sdc, error) {
 
 // ChangeSdcName returns a Sdc after changing its name
 // https://developer.dell.com/apis/4008/versions/4.0/PowerFlex_REST_API.json/paths/~1api~1instances~1Sdc::%7Bid%7D~1action~1setSdcName/post
-func (s *System) ChangeSdcName(idOfSdc, name string) (*Sdc, error) {
+func (s *System) ChangeSdcName(ctx context.Context, idOfSdc, name string) (*Sdc, error) {
 	defer TimeSpent("ChangeSdcName", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdc::%v/action/setSdcName", idOfSdc)
@@ -83,7 +84,7 @@ func (s *System) ChangeSdcName(idOfSdc, name string) (*Sdc, error) {
 	var body types.ChangeSdcNameParam = types.ChangeSdcNameParam{
 		SdcName: name,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, &sdc)
 	if err != nil {
 		return nil, err
@@ -93,7 +94,7 @@ func (s *System) ChangeSdcName(idOfSdc, name string) (*Sdc, error) {
 }
 
 // ChangeSdcPerfProfile returns a Sdc after changing its PerfProfile
-func (s *System) ChangeSdcPerfProfile(idOfSdc, perfProfile string) (*Sdc, error) {
+func (s *System) ChangeSdcPerfProfile(ctx context.Context, idOfSdc, perfProfile string) (*Sdc, error) {
 	defer TimeSpent("ChangeSdcPerfProfile", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdc::%v/action/setSdcPerformanceParameters", idOfSdc)
@@ -103,7 +104,7 @@ func (s *System) ChangeSdcPerfProfile(idOfSdc, perfProfile string) (*Sdc, error)
 	var body types.ChangeSdcPerfProfile = types.ChangeSdcPerfProfile{
 		PerfProfile: perfProfile,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, &sdc)
 	if err != nil {
 		return nil, err
@@ -113,10 +114,10 @@ func (s *System) ChangeSdcPerfProfile(idOfSdc, perfProfile string) (*Sdc, error)
 }
 
 // FindSdc returns a Sdc
-func (s *System) FindSdc(field, value string) (*Sdc, error) {
+func (s *System) FindSdc(ctx context.Context, field, value string) (*Sdc, error) {
 	defer TimeSpent("FindSdc", time.Now())
 
-	sdcs, err := s.GetSdc()
+	sdcs, err := s.GetSdc(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +134,7 @@ func (s *System) FindSdc(field, value string) (*Sdc, error) {
 }
 
 // ApproveSdcByGUID approves the Sdc When the Powerflex Array is operating in Guid RestrictedSdcMode.
-func (s *System) ApproveSdcByGUID(sdcGUID string) (*types.ApproveSdcByGUIDResponse, error) {
+func (s *System) ApproveSdcByGUID(ctx context.Context, sdcGUID string) (*types.ApproveSdcByGUIDResponse, error) {
 	defer TimeSpent("ApproveSdcByGUID", time.Now())
 
 	var resp types.ApproveSdcByGUIDResponse
@@ -144,7 +145,7 @@ func (s *System) ApproveSdcByGUID(sdcGUID string) (*types.ApproveSdcByGUIDRespon
 		SdcGUID: sdcGUID,
 	}
 
-	err := s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)
+	err := s.client.getJSONWithRetry(ctx, http.MethodPost, path, body, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +154,7 @@ func (s *System) ApproveSdcByGUID(sdcGUID string) (*types.ApproveSdcByGUIDRespon
 }
 
 // GetStatistics returns a Sdc statistcs
-func (sdc *Sdc) GetStatistics() (*types.SdcStatistics, error) {
+func (sdc *Sdc) GetStatistics(ctx context.Context) (*types.SdcStatistics, error) {
 	defer TimeSpent("GetStatistics", time.Now())
 
 	link, err := GetLink(sdc.Sdc.Links, "/api/Sdc/relationship/Statistics")
@@ -162,7 +163,7 @@ func (sdc *Sdc) GetStatistics() (*types.SdcStatistics, error) {
 	}
 
 	var stats types.SdcStatistics
-	err = sdc.client.getJSONWithRetry(
+	err = sdc.client.getJSONWithRetry(ctx,
 		http.MethodGet, link.HREF, nil, &stats)
 	if err != nil {
 		return nil, err
@@ -172,7 +173,7 @@ func (sdc *Sdc) GetStatistics() (*types.SdcStatistics, error) {
 }
 
 // GetVolume returns a volume
-func (sdc *Sdc) GetVolume() ([]*types.Volume, error) {
+func (sdc *Sdc) GetVolume(ctx context.Context) ([]*types.Volume, error) {
 	defer TimeSpent("GetVolume", time.Now())
 
 	link, err := GetLink(sdc.Sdc.Links, "/api/Sdc/relationship/Volume")
@@ -181,7 +182,7 @@ func (sdc *Sdc) GetVolume() ([]*types.Volume, error) {
 	}
 
 	var vols []*types.Volume
-	err = sdc.client.getJSONWithRetry(
+	err = sdc.client.getJSONWithRetry(ctx,
 		http.MethodGet, link.HREF, nil, &vols)
 	if err != nil {
 		return nil, err
@@ -191,11 +192,11 @@ func (sdc *Sdc) GetVolume() ([]*types.Volume, error) {
 }
 
 // FindVolumes returns volumes
-func (sdc *Sdc) FindVolumes() ([]*Volume, error) {
+func (sdc *Sdc) FindVolumes(ctx context.Context) ([]*Volume, error) {
 	defer TimeSpent("FindVolumes", time.Now())
 
 	var rlt []*Volume
-	vols, err := sdc.GetVolume()
+	vols, err := sdc.GetVolume(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +229,7 @@ func GetSdcLocalGUID() (string, error) {
 }
 
 // MapVolumeSdc maps a volume to Sdc
-func (v *Volume) MapVolumeSdc(
+func (v *Volume) MapVolumeSdc(ctx context.Context,
 	mapVolumeSdcParam *types.MapVolumeSdcParam,
 ) error {
 	defer TimeSpent("MapVolumeSdc", time.Now())
@@ -236,7 +237,7 @@ func (v *Volume) MapVolumeSdc(
 	path := fmt.Sprintf("/api/instances/Volume::%s/action/addMappedSdc",
 		v.Volume.ID)
 
-	err := v.client.getJSONWithRetry(
+	err := v.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, mapVolumeSdcParam, nil)
 	if err != nil {
 		return err
@@ -246,7 +247,7 @@ func (v *Volume) MapVolumeSdc(
 }
 
 // UnmapVolumeSdc unmaps a volume from Sdc
-func (v *Volume) UnmapVolumeSdc(
+func (v *Volume) UnmapVolumeSdc(ctx context.Context,
 	unmapVolumeSdcParam *types.UnmapVolumeSdcParam,
 ) error {
 	defer TimeSpent("UnmapVolumeSdc", time.Now())
@@ -254,7 +255,7 @@ func (v *Volume) UnmapVolumeSdc(
 	path := fmt.Sprintf("/api/instances/Volume::%s/action/removeMappedSdc",
 		v.Volume.ID)
 
-	err := v.client.getJSONWithRetry(
+	err := v.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, unmapVolumeSdcParam, nil)
 	if err != nil {
 		return err
@@ -264,7 +265,7 @@ func (v *Volume) UnmapVolumeSdc(
 }
 
 // SetMappedSdcLimits sets Sdc mapped limits
-func (v *Volume) SetMappedSdcLimits(
+func (v *Volume) SetMappedSdcLimits(ctx context.Context,
 	setMappedSdcLimitsParam *types.SetMappedSdcLimitsParam,
 ) error {
 	defer TimeSpent("SetMappedSdcLimits", time.Now())
@@ -273,7 +274,7 @@ func (v *Volume) SetMappedSdcLimits(
 		"/api/instances/Volume::%s/action/setMappedSdcLimits",
 		v.Volume.ID)
 
-	err := v.client.getJSONWithRetry(
+	err := v.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, setMappedSdcLimitsParam, nil)
 	if err != nil {
 		return err
@@ -283,14 +284,14 @@ func (v *Volume) SetMappedSdcLimits(
 }
 
 // RenameSdc renames the sdc with given name
-func (c *Client) RenameSdc(sdcID, name string) error {
+func (c *Client) RenameSdc(ctx context.Context, sdcID, name string) error {
 	path := fmt.Sprintf("/api/instances/Sdc::%s/action/setSdcName", sdcID)
 
 	renameSdcParam := &types.RenameSdcParam{
 		SdcName: name,
 	}
 
-	err := c.getJSONWithRetry(
+	err := c.getJSONWithRetry(ctx,
 		http.MethodPost, path, renameSdcParam, nil)
 	if err != nil {
 		return err
@@ -299,13 +300,13 @@ func (c *Client) RenameSdc(sdcID, name string) error {
 }
 
 // DeleteSdc deletes a Sdc against Id
-func (s *System) DeleteSdc(id string) error {
+func (s *System) DeleteSdc(ctx context.Context, id string) error {
 	defer TimeSpent("DeleteSdc", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdc::%v/action/removeSdc", id)
 
 	sdcParam := &types.EmptyPayload{}
-	err := s.client.getJSONWithRetry(http.MethodPost, path, sdcParam, nil)
+	err := s.client.getJSONWithRetry(ctx, http.MethodPost, path, sdcParam, nil)
 	if err != nil {
 		return err
 	}
@@ -314,7 +315,7 @@ func (s *System) DeleteSdc(id string) error {
 }
 
 // GetSdcIDByIP get a Sdc id by IP Address
-func (s *System) GetSdcIDByIP(ip string) (string, error) {
+func (s *System) GetSdcIDByIP(ctx context.Context, ip string) (string, error) {
 	defer TimeSpent("GetSdcId", time.Now())
 
 	path := fmt.Sprintf("/api/types/Sdc/instances/action/queryIdByKey")
@@ -322,7 +323,7 @@ func (s *System) GetSdcIDByIP(ip string) (string, error) {
 	sdcParam := &types.GetSdcIDByIPParam{
 		IP: ip,
 	}
-	sdcID, err := s.client.getStringWithRetry(http.MethodPost, path, sdcParam)
+	sdcID, err := s.client.getStringWithRetry(ctx, http.MethodPost, path, sdcParam)
 	if err != nil {
 		return "", err
 	}
@@ -331,14 +332,14 @@ func (s *System) GetSdcIDByIP(ip string) (string, error) {
 }
 
 // SetRestrictedMode sets the restricted mode for the system
-func (s *System) SetRestrictedMode(mode string) error {
+func (s *System) SetRestrictedMode(ctx context.Context, mode string) error {
 	defer TimeSpent("SetRestrictedMode", time.Now())
 
 	path := fmt.Sprintf("/api/instances/System::%v/action/setRestrictedSdcMode", s.System.ID)
 	sdcParam := &types.SetRestrictedMode{
 		RestrictedSdcMode: mode,
 	}
-	err := s.client.getJSONWithRetry(http.MethodPost, path, sdcParam, nil)
+	err := s.client.getJSONWithRetry(ctx, http.MethodPost, path, sdcParam, nil)
 	if err != nil {
 		return err
 	}
@@ -347,7 +348,7 @@ func (s *System) SetRestrictedMode(mode string) error {
 }
 
 // SetApprovedIps sets the approved IPs for a specific SDC in the system.
-func (s *System) SetApprovedIps(sdcID string, sdcApprovedIps []string) error {
+func (s *System) SetApprovedIps(ctx context.Context, sdcID string, sdcApprovedIps []string) error {
 	defer TimeSpent("SetApprovedIps", time.Now())
 
 	path := fmt.Sprintf("/api/instances/System::%v/action/setApprovedSdcIps", s.System.ID)
@@ -356,7 +357,7 @@ func (s *System) SetApprovedIps(sdcID string, sdcApprovedIps []string) error {
 		SdcApprovedIps: sdcApprovedIps,
 	}
 
-	err := s.client.getJSONWithRetry(http.MethodPost, path, sdcParam, nil)
+	err := s.client.getJSONWithRetry(ctx, http.MethodPost, path, sdcParam, nil)
 	if err != nil {
 		return err
 	}
@@ -365,7 +366,7 @@ func (s *System) SetApprovedIps(sdcID string, sdcApprovedIps []string) error {
 }
 
 // ApproveSdc approves an SDC
-func (s *System) ApproveSdc(approveSdcParam *types.ApproveSdcParam) (*types.ApproveSdcByGUIDResponse, error) {
+func (s *System) ApproveSdc(ctx context.Context, approveSdcParam *types.ApproveSdcParam) (*types.ApproveSdcByGUIDResponse, error) {
 	defer TimeSpent("ApproveSdc", time.Now())
 	var resp types.ApproveSdcByGUIDResponse
 
@@ -377,7 +378,7 @@ func (s *System) ApproveSdc(approveSdcParam *types.ApproveSdcParam) (*types.Appr
 		Name:    approveSdcParam.Name,
 	}
 
-	err := s.client.getJSONWithRetry(http.MethodPost, path, sdcParam, &resp)
+	err := s.client.getJSONWithRetry(ctx, http.MethodPost, path, sdcParam, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/sdc_test.go
+++ b/sdc_test.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -112,7 +113,7 @@ func Test_FindVolumes(t *testing.T) {
 			}
 
 			sdcClient := NewSdc(client, &sdc)
-			vols, err := sdcClient.FindVolumes()
+			vols, err := sdcClient.FindVolumes(context.Background())
 			for _, checkFn := range checkFns {
 				checkFn(t, vols, err)
 			}
@@ -163,7 +164,7 @@ func TestRenameSdc(t *testing.T) {
 			}
 
 			// calling RenameSdc with mock value
-			err = client.RenameSdc(tc.sdcID, tc.name)
+			err = client.RenameSdc(context.Background(), tc.sdcID, tc.name)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Renaming sdc did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)
@@ -297,7 +298,7 @@ func TestApproveSdc(t *testing.T) {
 				System: system,
 			}
 
-			resp, err := s.ApproveSdcByGUID(testCaseGuids[name])
+			resp, err := s.ApproveSdcByGUID(context.Background(), testCaseGuids[name])
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -344,7 +345,7 @@ func TestSetRestrictedMode(t *testing.T) {
 				System: &system,
 			}
 
-			err2 := s.SetRestrictedMode(tc.mode)
+			err2 := s.SetRestrictedMode(context.Background(), tc.mode)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Modifying restricted mode did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -401,7 +402,7 @@ func TestApproveSdcbyIP(t *testing.T) {
 				System: &system,
 			}
 
-			_, err2 := s.ApproveSdc(&tc.param)
+			_, err2 := s.ApproveSdc(context.Background(), &tc.param)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Approving SDC did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -456,7 +457,7 @@ func TestSetApprovedIps(t *testing.T) {
 				System: &system,
 			}
 
-			err2 := s.SetApprovedIps(tc.SdcID, tc.SdcIps)
+			err2 := s.SetApprovedIps(context.Background(), tc.SdcID, tc.SdcIps)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Approving SDC IPs did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)

--- a/sdt.go
+++ b/sdt.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -35,13 +36,13 @@ func NewSdt(client *Client, sdt *types.Sdt) *Sdt {
 }
 
 // GetAllSdts returns all sdt
-func (s *System) GetAllSdts() ([]types.Sdt, error) {
+func (s *System) GetAllSdts(ctx context.Context) ([]types.Sdt, error) {
 	defer TimeSpent("GetAllSdts", time.Now())
 
 	path := "/api/types/Sdt/instances"
 
 	var allSdts []types.Sdt
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &allSdts)
 	if err != nil {
 		return nil, err
@@ -51,13 +52,13 @@ func (s *System) GetAllSdts() ([]types.Sdt, error) {
 }
 
 // GetSdtByID returns an sdt searched by id
-func (s *System) GetSdtByID(id string) (*types.Sdt, error) {
+func (s *System) GetSdtByID(ctx context.Context, id string) (*types.Sdt, error) {
 	defer TimeSpent("GetSdtByID", time.Now())
 
 	path := fmt.Sprintf("api/instances/Sdt::%v", id)
 
 	var sdt types.Sdt
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &sdt)
 	if err != nil {
 		return nil, err
@@ -67,7 +68,7 @@ func (s *System) GetSdtByID(id string) (*types.Sdt, error) {
 }
 
 // CreateSdt creates a new Sdt
-func (pd *ProtectionDomain) CreateSdt(param *types.SdtParam) (*types.SdtResp, error) {
+func (pd *ProtectionDomain) CreateSdt(ctx context.Context, param *types.SdtParam) (*types.SdtResp, error) {
 	defer TimeSpent("CreateSdt", time.Now())
 
 	if len(param.IPList) == 0 {
@@ -78,13 +79,13 @@ func (pd *ProtectionDomain) CreateSdt(param *types.SdtParam) (*types.SdtResp, er
 
 	resp := &types.SdtResp{}
 	path := "/api/types/Sdt/instances"
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, param, resp)
 	return resp, err
 }
 
 // RenameSdt changes the name of the sdt.
-func (s *System) RenameSdt(id, name string) error {
+func (s *System) RenameSdt(ctx context.Context, id, name string) error {
 	defer TimeSpent("RenameSdt", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdt::%v/action/renameSdt", id)
@@ -92,7 +93,7 @@ func (s *System) RenameSdt(id, name string) error {
 	body := types.SdtRenameParam{
 		NewName: name,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, nil)
 	if err != nil {
 		return err
@@ -102,7 +103,7 @@ func (s *System) RenameSdt(id, name string) error {
 }
 
 // SetSdtNvmePort set the NVMe port for the sdt.
-func (s *System) SetSdtNvmePort(id string, port int) error {
+func (s *System) SetSdtNvmePort(ctx context.Context, id string, port int) error {
 	defer TimeSpent("SetSdtNvmePort", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdt::%v/action/modifyNvmePort", id)
@@ -110,7 +111,7 @@ func (s *System) SetSdtNvmePort(id string, port int) error {
 	body := types.SdtNvmePortParam{
 		NewNvmePort: types.IntString(port),
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, nil)
 	if err != nil {
 		return err
@@ -120,7 +121,7 @@ func (s *System) SetSdtNvmePort(id string, port int) error {
 }
 
 // SetSdtStoragePort sets the storage port for the sdt.
-func (s *System) SetSdtStoragePort(id string, port int) error {
+func (s *System) SetSdtStoragePort(ctx context.Context, id string, port int) error {
 	defer TimeSpent("SetSdtStoragePort", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdt::%v/action/modifyStoragePort", id)
@@ -128,7 +129,7 @@ func (s *System) SetSdtStoragePort(id string, port int) error {
 	body := types.SdtStoragePortParam{
 		NewStoragePort: types.IntString(port),
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, nil)
 	if err != nil {
 		return err
@@ -138,7 +139,7 @@ func (s *System) SetSdtStoragePort(id string, port int) error {
 }
 
 // SetSdtDiscoveryPort sets the discovery port for the sdt.
-func (s *System) SetSdtDiscoveryPort(id string, port int) error {
+func (s *System) SetSdtDiscoveryPort(ctx context.Context, id string, port int) error {
 	defer TimeSpent("SetSdtDiscoveryPort", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdt::%v/action/modifyDiscoveryPort", id)
@@ -146,7 +147,7 @@ func (s *System) SetSdtDiscoveryPort(id string, port int) error {
 	body := types.SdtDiscoveryPortParam{
 		NewDiscoveryPort: types.IntString(port),
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, nil)
 	if err != nil {
 		return err
@@ -156,7 +157,7 @@ func (s *System) SetSdtDiscoveryPort(id string, port int) error {
 }
 
 // AddSdtTargetIP adds target IP and role for the sdt.
-func (s *System) AddSdtTargetIP(id, ip, role string) error {
+func (s *System) AddSdtTargetIP(ctx context.Context, id, ip, role string) error {
 	defer TimeSpent("AddSdtTargetIP", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdt::%v/action/addIp", id)
@@ -165,7 +166,7 @@ func (s *System) AddSdtTargetIP(id, ip, role string) error {
 		IP:   ip,
 		Role: role,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, nil)
 	if err != nil {
 		return err
@@ -175,7 +176,7 @@ func (s *System) AddSdtTargetIP(id, ip, role string) error {
 }
 
 // RemoveSdtTargetIP removes target IP and role from the sdt.
-func (s *System) RemoveSdtTargetIP(id, ip string) error {
+func (s *System) RemoveSdtTargetIP(ctx context.Context, id, ip string) error {
 	defer TimeSpent("RemoveSdtTargetIP", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdt::%v/action/removeIp", id)
@@ -183,7 +184,7 @@ func (s *System) RemoveSdtTargetIP(id, ip string) error {
 	body := types.SdtRemoveIPParam{
 		IP: ip,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, nil)
 	if err != nil {
 		return err
@@ -193,7 +194,7 @@ func (s *System) RemoveSdtTargetIP(id, ip string) error {
 }
 
 // ModifySdtIPRole modify target IP role for the sdt.
-func (s *System) ModifySdtIPRole(id, ip, role string) error {
+func (s *System) ModifySdtIPRole(ctx context.Context, id, ip, role string) error {
 	defer TimeSpent("ModifySdtIPRole", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdt::%v/action/modifyIpRole", id)
@@ -202,7 +203,7 @@ func (s *System) ModifySdtIPRole(id, ip, role string) error {
 		IP:   ip,
 		Role: role,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, nil)
 	if err != nil {
 		return err
@@ -212,13 +213,13 @@ func (s *System) ModifySdtIPRole(id, ip, role string) error {
 }
 
 // DeleteSdt deletes the sdt
-func (s *System) DeleteSdt(id string) error {
+func (s *System) DeleteSdt(ctx context.Context, id string) error {
 	defer TimeSpent("DeleteSdt", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdt::%v/action/removeSdt", id)
 
 	param := &types.EmptyPayload{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, param, nil)
 	if err != nil {
 		return err
@@ -227,13 +228,13 @@ func (s *System) DeleteSdt(id string) error {
 }
 
 // EnterSdtMaintenanceMode enter sdt maintenance mode
-func (s *System) EnterSdtMaintenanceMode(id string) error {
+func (s *System) EnterSdtMaintenanceMode(ctx context.Context, id string) error {
 	defer TimeSpent("EnterSdtMaintenanceMode", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdt::%v/action/enterMaintenanceMode", id)
 
 	param := &types.EmptyPayload{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, param, nil)
 	if err != nil {
 		return err
@@ -242,13 +243,13 @@ func (s *System) EnterSdtMaintenanceMode(id string) error {
 }
 
 // ExitSdtMaintenanceMode exit sdt maintenance mode
-func (s *System) ExitSdtMaintenanceMode(id string) error {
+func (s *System) ExitSdtMaintenanceMode(ctx context.Context, id string) error {
 	defer TimeSpent("ExitSdtMaintenanceMode", time.Now())
 
 	path := fmt.Sprintf("/api/instances/Sdt::%v/action/exitMaintenanceMode", id)
 
 	param := &types.EmptyPayload{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, param, nil)
 	if err != nil {
 		return err

--- a/sdt_test.go
+++ b/sdt_test.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -129,7 +130,7 @@ func Test_GetAllSdts(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			sdts, err := system.GetAllSdts()
+			sdts, err := system.GetAllSdts(context.Background())
 
 			for _, checkFn := range checkFns {
 				checkFn(t, sdts, err)
@@ -242,7 +243,7 @@ func Test_GetSdtByID(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			sdt, err := system.GetSdtByID("mock-id")
+			sdt, err := system.GetSdtByID(context.Background(), "mock-id")
 
 			for _, checkFn := range checkFns {
 				checkFn(t, sdt, err)
@@ -344,7 +345,7 @@ func Test_CreateSdt(t *testing.T) {
 
 			client, _ := NewClientWithArgs(server.URL, "", math.MaxInt64, true, false)
 			pd := NewProtectionDomain(client)
-			resp, err := pd.CreateSdt(sdtParam)
+			resp, err := pd.CreateSdt(context.Background(), sdtParam)
 
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
@@ -408,7 +409,7 @@ func Test_RenameSdt(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.RenameSdt("mock-id", "new-mock-name")
+			err := system.RenameSdt(context.Background(), "mock-id", "new-mock-name")
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -472,7 +473,7 @@ func Test_SetSdtNvmePort(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.SetSdtNvmePort("mock-id", 1234)
+			err := system.SetSdtNvmePort(context.Background(), "mock-id", 1234)
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -536,7 +537,7 @@ func Test_SetSdtStoragePort(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.SetSdtStoragePort("mock-id", 1234)
+			err := system.SetSdtStoragePort(context.Background(), "mock-id", 1234)
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -600,7 +601,7 @@ func Test_SetSdtDiscoveryPort(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.SetSdtDiscoveryPort("mock-id", 1234)
+			err := system.SetSdtDiscoveryPort(context.Background(), "mock-id", 1234)
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -664,7 +665,7 @@ func Test_AddSdtTargetIP(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.AddSdtTargetIP("mock-id", "192.168.0.2", "StorageAndHost")
+			err := system.AddSdtTargetIP(context.Background(), "mock-id", "192.168.0.2", "StorageAndHost")
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -728,7 +729,7 @@ func Test_RemoveSdtTargetIP(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.RemoveSdtTargetIP("mock-id", "192.168.0.2")
+			err := system.RemoveSdtTargetIP(context.Background(), "mock-id", "192.168.0.2")
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -792,7 +793,7 @@ func Test_ModifySdtIPRole(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.ModifySdtIPRole("mock-id", "192.168.0.2", "StorageOnly")
+			err := system.ModifySdtIPRole(context.Background(), "mock-id", "192.168.0.2", "StorageOnly")
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -856,7 +857,7 @@ func Test_DeleteSdt(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.DeleteSdt("mock-id")
+			err := system.DeleteSdt(context.Background(), "mock-id")
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -920,7 +921,7 @@ func Test_EnterSdtMaintenanceMode(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.EnterSdtMaintenanceMode("mock-id")
+			err := system.EnterSdtMaintenanceMode(context.Background(), "mock-id")
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
@@ -984,7 +985,7 @@ func Test_ExitSdtMaintenanceMode(t *testing.T) {
 				System: &sys,
 				client: client,
 			}
-			err := system.ExitSdtMaintenanceMode("mock-id")
+			err := system.ExitSdtMaintenanceMode(context.Background(), "mock-id")
 
 			for _, checkFn := range checkFns {
 				checkFn(t, err)

--- a/snapshot_policy.go
+++ b/snapshot_policy.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -21,12 +22,12 @@ import (
 )
 
 // CreateSnapshotPolicy creates a snapshot policy on the PowerFlex array
-func (s *System) CreateSnapshotPolicy(snapPolicy *types.SnapshotPolicyCreateParam) (string, error) {
+func (s *System) CreateSnapshotPolicy(ctx context.Context, snapPolicy *types.SnapshotPolicyCreateParam) (string, error) {
 	defer TimeSpent("crate snapshot policy", time.Now())
 
 	path := fmt.Sprintf("/api/types/SnapshotPolicy/instances")
 	snapResp := types.SnapShotPolicyCreateResp{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, snapPolicy, &snapResp)
 	if err != nil {
 		return "", err
@@ -35,10 +36,10 @@ func (s *System) CreateSnapshotPolicy(snapPolicy *types.SnapshotPolicyCreatePara
 }
 
 // RemoveSnapshotPolicy removes a snapshot policy from the PowerFlex array
-func (s *System) RemoveSnapshotPolicy(id string) error {
+func (s *System) RemoveSnapshotPolicy(ctx context.Context, id string) error {
 	path := fmt.Sprintf("/api/instances/SnapshotPolicy::%v/action/removeSnapshotPolicy", id)
 	removeParam := &types.EmptyPayload{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, removeParam, nil)
 	if err != nil {
 		return err
@@ -47,12 +48,12 @@ func (s *System) RemoveSnapshotPolicy(id string) error {
 }
 
 // RenameSnapshotPolicy renames a snapshot policy
-func (s *System) RenameSnapshotPolicy(id, name string) error {
+func (s *System) RenameSnapshotPolicy(ctx context.Context, id, name string) error {
 	path := fmt.Sprintf("/api/instances/SnapshotPolicy::%v/action/renameSnapshotPolicy", id)
 	renameSnap := &types.SnapshotPolicyRenameParam{
 		NewName: name,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, renameSnap, nil)
 	if err != nil {
 		return err
@@ -61,9 +62,9 @@ func (s *System) RenameSnapshotPolicy(id, name string) error {
 }
 
 // ModifySnapshotPolicy modifies a snapshot policy
-func (s *System) ModifySnapshotPolicy(modifysnapPolicy *types.SnapshotPolicyModifyParam, id string) error {
+func (s *System) ModifySnapshotPolicy(ctx context.Context, modifysnapPolicy *types.SnapshotPolicyModifyParam, id string) error {
 	path := fmt.Sprintf("/api/instances/SnapshotPolicy::%v/action/modifySnapshotPolicy", id)
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, modifysnapPolicy, nil)
 	if err != nil {
 		return err
@@ -72,9 +73,9 @@ func (s *System) ModifySnapshotPolicy(modifysnapPolicy *types.SnapshotPolicyModi
 }
 
 // AssignVolumeToSnapshotPolicy assigns volume to a snapshot policy
-func (s *System) AssignVolumeToSnapshotPolicy(assignVoltoSnap *types.AssignVolumeToSnapshotPolicyParam, id string) error {
+func (s *System) AssignVolumeToSnapshotPolicy(ctx context.Context, assignVoltoSnap *types.AssignVolumeToSnapshotPolicyParam, id string) error {
 	path := fmt.Sprintf("/api/instances/SnapshotPolicy::%v/action/addSourceVolumeToSnapshotPolicy", id)
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, assignVoltoSnap, nil)
 	if err != nil {
 		return err
@@ -83,9 +84,9 @@ func (s *System) AssignVolumeToSnapshotPolicy(assignVoltoSnap *types.AssignVolum
 }
 
 // UnassignVolumeFromSnapshotPolicy unassigns volume from a snapshot policy
-func (s *System) UnassignVolumeFromSnapshotPolicy(UnassignVolFromSnap *types.AssignVolumeToSnapshotPolicyParam, id string) error {
+func (s *System) UnassignVolumeFromSnapshotPolicy(ctx context.Context, UnassignVolFromSnap *types.AssignVolumeToSnapshotPolicyParam, id string) error {
 	path := fmt.Sprintf("/api/instances/SnapshotPolicy::%v/action/removeSourceVolumeFromSnapshotPolicy", id)
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, UnassignVolFromSnap, nil)
 	if err != nil {
 		return err
@@ -94,10 +95,10 @@ func (s *System) UnassignVolumeFromSnapshotPolicy(UnassignVolFromSnap *types.Ass
 }
 
 // PauseSnapshotPolicy pause a snapshot policy
-func (s *System) PauseSnapshotPolicy(id string) error {
+func (s *System) PauseSnapshotPolicy(ctx context.Context, id string) error {
 	path := fmt.Sprintf("/api/instances/SnapshotPolicy::%v/action/pauseSnapshotPolicy", id)
 	pauseParam := &types.EmptyPayload{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, pauseParam, nil)
 	if err != nil {
 		return err
@@ -106,10 +107,10 @@ func (s *System) PauseSnapshotPolicy(id string) error {
 }
 
 // ResumeSnapshotPolicy resume a snapshot policy which was paused
-func (s *System) ResumeSnapshotPolicy(id string) error {
+func (s *System) ResumeSnapshotPolicy(ctx context.Context, id string) error {
 	path := fmt.Sprintf("/api/instances/SnapshotPolicy::%v/action/resumeSnapshotPolicy", id)
 	resumeParam := &types.EmptyPayload{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, resumeParam, nil)
 	if err != nil {
 		return err
@@ -118,10 +119,10 @@ func (s *System) ResumeSnapshotPolicy(id string) error {
 }
 
 // GetSourceVolume returns a list of volumes assigned to snapshot policy
-func (s *System) GetSourceVolume(id string) ([]*types.Volume, error) {
+func (s *System) GetSourceVolume(ctx context.Context, id string) ([]*types.Volume, error) {
 	var volumes []*types.Volume
 	path := fmt.Sprintf("/api/instances/SnapshotPolicy::%v/relationships/SourceVolume", id)
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &volumes)
 	if err != nil {
 		return nil, err

--- a/snapshot_policy_test.go
+++ b/snapshot_policy_test.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"math"
 	"net/http"
@@ -67,7 +68,7 @@ func TestCreateSnapshotPolicy(t *testing.T) {
 				client: client,
 			}
 
-			ID2, errSnap = s.CreateSnapshotPolicy(tc.fs)
+			ID2, errSnap = s.CreateSnapshotPolicy(context.Background(), tc.fs)
 			if errSnap != nil {
 				if tc.expected == nil {
 					t.Errorf("Creating Snapshot Policy did not work as expected, \n\tgot: %s \n\twant: %v", errSnap, tc.expected)
@@ -114,7 +115,7 @@ func TestModifySnapshotPolicyName(t *testing.T) {
 			s := System{
 				client: client,
 			}
-			err2 := s.RenameSnapshotPolicy(tc.id, tc.name)
+			err2 := s.RenameSnapshotPolicy(context.Background(), tc.id, tc.name)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Modifying snapshot policy did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -168,7 +169,7 @@ func TestModifySnapshotPolicy(t *testing.T) {
 				client: client,
 			}
 
-			err2 := s.ModifySnapshotPolicy(tc.snap, tc.id)
+			err2 := s.ModifySnapshotPolicy(context.Background(), tc.snap, tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Modifying snapshot policy did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -227,7 +228,7 @@ func TestAssignSnapshotPolicy(t *testing.T) {
 				client: client,
 			}
 
-			err2 := s.AssignVolumeToSnapshotPolicy(tc.snap, tc.id)
+			err2 := s.AssignVolumeToSnapshotPolicy(context.Background(), tc.snap, tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Assigning volume to snapshot policy did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -297,7 +298,7 @@ func TestUnassignSnapshotPolicy(t *testing.T) {
 				client: client,
 			}
 
-			err2 := s.AssignVolumeToSnapshotPolicy(tc.snap, tc.id)
+			err2 := s.AssignVolumeToSnapshotPolicy(context.Background(), tc.snap, tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Assigning volume to snapshot policy did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -342,7 +343,7 @@ func TestPauseSnapshotPolicy(t *testing.T) {
 				client: client,
 			}
 
-			err2 := s.PauseSnapshotPolicy(tc.id)
+			err2 := s.PauseSnapshotPolicy(context.Background(), tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Pausing snapshot policy did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -387,7 +388,7 @@ func TestResumeSnapshotPolicy(t *testing.T) {
 				client: client,
 			}
 
-			err2 := s.ResumeSnapshotPolicy(tc.id)
+			err2 := s.ResumeSnapshotPolicy(context.Background(), tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Resuming snapshot policy did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -432,7 +433,7 @@ func TestDeleteSnapshotPolicy(t *testing.T) {
 				client: client,
 			}
 
-			err2 := s.RemoveSnapshotPolicy(tc.id)
+			err2 := s.RemoveSnapshotPolicy(context.Background(), tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Removing snapshot policy did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -477,7 +478,7 @@ func TestGetSourceVolume(t *testing.T) {
 				client: client,
 			}
 
-			_, err2 := s.GetSourceVolume(tc.id)
+			_, err2 := s.GetSourceVolume(context.Background(), tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Assigning volume to snapshot policy did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)

--- a/sso_user.go
+++ b/sso_user.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -21,10 +22,10 @@ import (
 )
 
 // GetSSOUser retrieves the details of an SSO user by their ID.
-func (c *Client) GetSSOUser(userID string) (*types.SSOUserDetails, error) {
+func (c *Client) GetSSOUser(ctx context.Context, userID string) (*types.SSOUserDetails, error) {
 	path := fmt.Sprintf("/rest/v1/users/%s", userID)
 	user := &types.SSOUserDetails{}
-	err := c.getJSONWithRetry(http.MethodGet, path, nil, &user)
+	err := c.getJSONWithRetry(ctx, http.MethodGet, path, nil, &user)
 	if err != nil {
 		return nil, err
 	}
@@ -33,11 +34,11 @@ func (c *Client) GetSSOUser(userID string) (*types.SSOUserDetails, error) {
 }
 
 // GetSSOUserByFilters retrieves the details of an SSO user by filter.
-func (c *Client) GetSSOUserByFilters(key string, value string) (*types.SSOUserList, error) {
+func (c *Client) GetSSOUserByFilters(ctx context.Context, key string, value string) (*types.SSOUserList, error) {
 	encodedValue := url.QueryEscape(value)
 	path := `/rest/v1/users?filter=` + key + `%20eq%20%22` + encodedValue + `%22`
 	users := &types.SSOUserList{}
-	err := c.getJSONWithRetry(http.MethodGet, path, nil, &users)
+	err := c.getJSONWithRetry(ctx, http.MethodGet, path, nil, &users)
 	if err != nil {
 		return nil, err
 	}
@@ -45,9 +46,9 @@ func (c *Client) GetSSOUserByFilters(key string, value string) (*types.SSOUserLi
 }
 
 // CreateSSOUser creates a new SSO user with the given parameters.
-func (c *Client) CreateSSOUser(userParam *types.SSOUserCreateParam) (*types.SSOUserDetails, error) {
+func (c *Client) CreateSSOUser(ctx context.Context, userParam *types.SSOUserCreateParam) (*types.SSOUserDetails, error) {
 	userResp := &types.SSOUserDetails{}
-	err := c.getJSONWithRetry(http.MethodPost, "/rest/v1/users", userParam, &userResp)
+	err := c.getJSONWithRetry(ctx, http.MethodPost, "/rest/v1/users", userParam, &userResp)
 	if err != nil {
 		return nil, err
 	}
@@ -55,19 +56,19 @@ func (c *Client) CreateSSOUser(userParam *types.SSOUserCreateParam) (*types.SSOU
 }
 
 // ModifySSOUser modifies the details of an SSO user by their ID.
-func (c *Client) ModifySSOUser(userID string, userParam *types.SSOUserModifyParam) (*types.SSOUserDetails, error) {
+func (c *Client) ModifySSOUser(ctx context.Context, userID string, userParam *types.SSOUserModifyParam) (*types.SSOUserDetails, error) {
 	path := fmt.Sprintf("/rest/v1/users/%s", userID)
-	err := c.getJSONWithRetry(http.MethodPatch, path, userParam, nil)
+	err := c.getJSONWithRetry(ctx, http.MethodPatch, path, userParam, nil)
 	if err != nil {
 		return nil, err
 	}
-	return c.GetSSOUser(userID)
+	return c.GetSSOUser(ctx, userID)
 }
 
 // ResetSSOUserPassword resets the password of an SSO user by their ID.
-func (c *Client) ResetSSOUserPassword(userID string, userParam *types.SSOUserModifyParam) error {
+func (c *Client) ResetSSOUserPassword(ctx context.Context, userID string, userParam *types.SSOUserModifyParam) error {
 	path := fmt.Sprintf("/rest/v1/users/%s/reset-password", userID)
-	err := c.getJSONWithRetry(http.MethodPost, path, userParam, nil)
+	err := c.getJSONWithRetry(ctx, http.MethodPost, path, userParam, nil)
 	if err != nil {
 		return err
 	}
@@ -75,9 +76,9 @@ func (c *Client) ResetSSOUserPassword(userID string, userParam *types.SSOUserMod
 }
 
 // DeleteSSOUser deletes an SSO user by their ID.
-func (c *Client) DeleteSSOUser(userID string) error {
+func (c *Client) DeleteSSOUser(ctx context.Context, userID string) error {
 	path := fmt.Sprintf("/rest/v1/users/%s", userID)
-	err := c.getJSONWithRetry(http.MethodDelete, path, nil, nil)
+	err := c.getJSONWithRetry(ctx, http.MethodDelete, path, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/sso_user_test.go
+++ b/sso_user_test.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -62,7 +63,7 @@ func TestCreateSSOUser(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err2 := client.CreateSSOUser(&tc.user)
+			_, err2 := client.CreateSSOUser(context.Background(), &tc.user)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Creating user did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -103,7 +104,7 @@ func TestGetSSOUser(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err2 := client.GetSSOUser(tc.id)
+			_, err2 := client.GetSSOUser(context.Background(), tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Getting user details did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -140,7 +141,7 @@ func TestGetSSOUserByFilters(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err2 := client.GetSSOUserByFilters(tc.username, "admin")
+			_, err2 := client.GetSSOUserByFilters(context.Background(), tc.username, "admin")
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Getting user details did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -188,7 +189,7 @@ func TestModifySSOUser(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err2 := client.ModifySSOUser(tc.id, &tc.user)
+			_, err2 := client.ModifySSOUser(context.Background(), tc.id, &tc.user)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Modifying user did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -229,7 +230,7 @@ func TestResetSSOUserPassword(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err2 := client.ResetSSOUserPassword(tc.id, &tc.user)
+			err2 := client.ResetSSOUserPassword(context.Background(), tc.id, &tc.user)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Resetting user password did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -270,7 +271,7 @@ func TestDeleteSSOUser(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err2 := client.DeleteSSOUser(tc.id)
+			err2 := client.DeleteSSOUser(context.Background(), tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Deleting user did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -296,7 +297,7 @@ func TestGetSSOUserNegative(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	details, err := client.GetSSOUser("93634330-6ffd-4d17-a22a-d3ec701e73d4")
+	details, err := client.GetSSOUser(context.Background(), "93634330-6ffd-4d17-a22a-d3ec701e73d4")
 	assert.Nil(t, details)
 	assert.NotNil(t, err)
 }
@@ -313,7 +314,7 @@ func TestDeleteSSOUserNegative(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = client.DeleteSSOUser("93634330-6ffd-4d17-a22a-d3ec701e73d4")
+	err = client.DeleteSSOUser(context.Background(), "93634330-6ffd-4d17-a22a-d3ec701e73d4")
 	assert.NotNil(t, err)
 }
 
@@ -335,6 +336,6 @@ func TestCreateSSOUserNegative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = client.CreateSSOUser(user)
+	_, err = client.CreateSSOUser(context.Background(), user)
 	assert.NotNil(t, err)
 }

--- a/storagepool.go
+++ b/storagepool.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -44,11 +45,11 @@ func NewStoragePoolEx(client *Client, pool *types.StoragePool) *StoragePool {
 }
 
 // CreateStoragePool creates a storage pool
-func (pd *ProtectionDomain) CreateStoragePool(sp *types.StoragePoolParam) (string, error) {
+func (pd *ProtectionDomain) CreateStoragePool(ctx context.Context, sp *types.StoragePoolParam) (string, error) {
 	path := fmt.Sprintf("/api/types/StoragePool/instances")
 	sp.ProtectionDomainID = pd.ProtectionDomain.ID
 	spResponse := types.StoragePoolResp{}
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, sp, &spResponse)
 	if err != nil {
 		return "", err
@@ -57,7 +58,7 @@ func (pd *ProtectionDomain) CreateStoragePool(sp *types.StoragePoolParam) (strin
 }
 
 // ModifyStoragePoolName Modifies Storagepool Name
-func (pd *ProtectionDomain) ModifyStoragePoolName(ID, name string) (string, error) {
+func (pd *ProtectionDomain) ModifyStoragePoolName(ctx context.Context, ID, name string) (string, error) {
 	storagePoolParam := &types.ModifyStoragePoolName{
 		Name: name,
 	}
@@ -65,7 +66,7 @@ func (pd *ProtectionDomain) ModifyStoragePoolName(ID, name string) (string, erro
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setStoragePoolName", ID)
 
 	spResp := types.StoragePoolResp{}
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, storagePoolParam, &spResp)
 	if err != nil {
 		return "", err
@@ -75,7 +76,7 @@ func (pd *ProtectionDomain) ModifyStoragePoolName(ID, name string) (string, erro
 }
 
 // ModifyStoragePoolMedia Modifies Storagepool Media Type
-func (pd *ProtectionDomain) ModifyStoragePoolMedia(ID, mediaType string) (string, error) {
+func (pd *ProtectionDomain) ModifyStoragePoolMedia(ctx context.Context, ID, mediaType string) (string, error) {
 	storagePool := &types.StoragePoolMediaType{
 		MediaType: mediaType,
 	}
@@ -83,7 +84,7 @@ func (pd *ProtectionDomain) ModifyStoragePoolMedia(ID, mediaType string) (string
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setMediaType", ID)
 
 	spResp := types.StoragePoolResp{}
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, storagePool, &spResp)
 	if err != nil {
 		return "", err
@@ -93,7 +94,7 @@ func (pd *ProtectionDomain) ModifyStoragePoolMedia(ID, mediaType string) (string
 }
 
 // ModifyRMCache Sets Read RAM Cache
-func (sp *StoragePool) ModifyRMCache(useRmcache string) error {
+func (sp *StoragePool) ModifyRMCache(ctx context.Context, useRmcache string) error {
 	link, err := GetLink(sp.StoragePool.Links, "self")
 	if err != nil {
 		return err
@@ -102,19 +103,19 @@ func (sp *StoragePool) ModifyRMCache(useRmcache string) error {
 	payload := &types.StoragePoolUseRmCache{
 		UseRmcache: useRmcache,
 	}
-	err = sp.client.getJSONWithRetry(
+	err = sp.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, payload, nil)
 	return err
 }
 
 // EnableRFCache Enables RFCache
-func (pd *ProtectionDomain) EnableRFCache(ID string) (string, error) {
+func (pd *ProtectionDomain) EnableRFCache(ctx context.Context, ID string) (string, error) {
 	storagePoolParam := &types.StoragePoolUseRfCache{}
 
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/enableRfcache", ID)
 
 	spResp := types.StoragePoolResp{}
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, storagePoolParam, &spResp)
 	if err != nil {
 		return "", err
@@ -124,12 +125,12 @@ func (pd *ProtectionDomain) EnableRFCache(ID string) (string, error) {
 }
 
 // EnableOrDisableZeroPadding Enables / disables zero padding
-func (pd *ProtectionDomain) EnableOrDisableZeroPadding(ID string, zeroPadValue string) error {
+func (pd *ProtectionDomain) EnableOrDisableZeroPadding(ctx context.Context, ID string, zeroPadValue string) error {
 	zeroPaddedParam := &types.StoragePoolZeroPadEnabled{
 		ZeroPadEnabled: zeroPadValue,
 	}
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setZeroPaddingPolicy", ID)
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, zeroPaddedParam, nil)
 	if err != nil {
 		return err
@@ -138,12 +139,12 @@ func (pd *ProtectionDomain) EnableOrDisableZeroPadding(ID string, zeroPadValue s
 }
 
 // SetReplicationJournalCapacity Sets replication journal capacity
-func (pd *ProtectionDomain) SetReplicationJournalCapacity(ID string, replicationJournalCapacity string) error {
+func (pd *ProtectionDomain) SetReplicationJournalCapacity(ctx context.Context, ID string, replicationJournalCapacity string) error {
 	replicationJournalCapacityParam := &types.ReplicationJournalCapacityParam{
 		ReplicationJournalCapacityMaxRatio: replicationJournalCapacity,
 	}
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setReplicationJournalCapacity", ID)
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, replicationJournalCapacityParam, nil)
 	if err != nil {
 		return err
@@ -152,9 +153,9 @@ func (pd *ProtectionDomain) SetReplicationJournalCapacity(ID string, replication
 }
 
 // SetCapacityAlertThreshold Sets high or critical capacity alert threshold
-func (pd *ProtectionDomain) SetCapacityAlertThreshold(ID string, capacityAlertThreshold *types.CapacityAlertThresholdParam) error {
+func (pd *ProtectionDomain) SetCapacityAlertThreshold(ctx context.Context, ID string, capacityAlertThreshold *types.CapacityAlertThresholdParam) error {
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setCapacityAlertThresholds", ID)
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, capacityAlertThreshold, nil)
 	if err != nil {
 		return err
@@ -163,9 +164,9 @@ func (pd *ProtectionDomain) SetCapacityAlertThreshold(ID string, capacityAlertTh
 }
 
 // SetProtectedMaintenanceModeIoPriorityPolicy sets protected maintenance mode IO priority policy
-func (pd *ProtectionDomain) SetProtectedMaintenanceModeIoPriorityPolicy(ID string, protectedMaintenanceModeParam *types.ProtectedMaintenanceModeParam) error {
+func (pd *ProtectionDomain) SetProtectedMaintenanceModeIoPriorityPolicy(ctx context.Context, ID string, protectedMaintenanceModeParam *types.ProtectedMaintenanceModeParam) error {
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setProtectedMaintenanceModeIoPriorityPolicy", ID)
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, protectedMaintenanceModeParam, nil)
 	if err != nil {
 		return err
@@ -174,12 +175,12 @@ func (pd *ProtectionDomain) SetProtectedMaintenanceModeIoPriorityPolicy(ID strin
 }
 
 // SetRebalanceEnabled sets rebalance enabled.
-func (pd *ProtectionDomain) SetRebalanceEnabled(ID string, rebalanceEnabledValue string) error {
+func (pd *ProtectionDomain) SetRebalanceEnabled(ctx context.Context, ID string, rebalanceEnabledValue string) error {
 	rebalanceEnabledParam := &types.RebalanceEnabledParam{
 		RebalanceEnabled: rebalanceEnabledValue,
 	}
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setRebalanceEnabled", ID)
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, rebalanceEnabledParam, nil)
 	if err != nil {
 		return err
@@ -188,9 +189,9 @@ func (pd *ProtectionDomain) SetRebalanceEnabled(ID string, rebalanceEnabledValue
 }
 
 // SetRebalanceIoPriorityPolicy Sets rebalance I/O priority policy
-func (pd *ProtectionDomain) SetRebalanceIoPriorityPolicy(ID string, protectedMaintenanceModeParam *types.ProtectedMaintenanceModeParam) error {
+func (pd *ProtectionDomain) SetRebalanceIoPriorityPolicy(ctx context.Context, ID string, protectedMaintenanceModeParam *types.ProtectedMaintenanceModeParam) error {
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setRebalanceIoPriorityPolicy", ID)
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, protectedMaintenanceModeParam, nil)
 	if err != nil {
 		return err
@@ -199,9 +200,9 @@ func (pd *ProtectionDomain) SetRebalanceIoPriorityPolicy(ID string, protectedMai
 }
 
 // SetVTreeMigrationIOPriorityPolicy Sets V-Tree migration I/O priority policy
-func (pd *ProtectionDomain) SetVTreeMigrationIOPriorityPolicy(ID string, protectedMaintenanceModeParam *types.ProtectedMaintenanceModeParam) error {
+func (pd *ProtectionDomain) SetVTreeMigrationIOPriorityPolicy(ctx context.Context, ID string, protectedMaintenanceModeParam *types.ProtectedMaintenanceModeParam) error {
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setVTreeMigrationIoPriorityPolicy", ID)
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, protectedMaintenanceModeParam, nil)
 	if err != nil {
 		return err
@@ -210,12 +211,12 @@ func (pd *ProtectionDomain) SetVTreeMigrationIOPriorityPolicy(ID string, protect
 }
 
 // SetSparePercentage Sets spare percentage
-func (pd *ProtectionDomain) SetSparePercentage(ID string, sparePercentageValue string) error {
+func (pd *ProtectionDomain) SetSparePercentage(ctx context.Context, ID string, sparePercentageValue string) error {
 	percentageParam := &types.SparePercentageParam{
 		SparePercentage: sparePercentageValue,
 	}
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setSparePercentage", ID)
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, percentageParam, nil)
 	if err != nil {
 		return err
@@ -224,12 +225,12 @@ func (pd *ProtectionDomain) SetSparePercentage(ID string, sparePercentageValue s
 }
 
 // SetRMcacheWriteHandlingMode Sets RMcache write handling mode
-func (pd *ProtectionDomain) SetRMcacheWriteHandlingMode(ID string, writeHandlingModeValue string) error {
+func (pd *ProtectionDomain) SetRMcacheWriteHandlingMode(ctx context.Context, ID string, writeHandlingModeValue string) error {
 	writeHandlingParam := &types.RmcacheWriteHandlingModeParam{
 		RmcacheWriteHandlingMode: writeHandlingModeValue,
 	}
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setRmcacheWriteHandlingMode", ID)
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, writeHandlingParam, nil)
 	if err != nil {
 		return err
@@ -238,12 +239,12 @@ func (pd *ProtectionDomain) SetRMcacheWriteHandlingMode(ID string, writeHandling
 }
 
 // SetRebuildEnabled Sets Rebuild Enabled
-func (pd *ProtectionDomain) SetRebuildEnabled(ID string, rebuildEnabledValue string) error {
+func (pd *ProtectionDomain) SetRebuildEnabled(ctx context.Context, ID string, rebuildEnabledValue string) error {
 	rebuildEnabled := &types.RebuildEnabledParam{
 		RebuildEnabled: rebuildEnabledValue,
 	}
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setRebuildEnabled", ID)
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, rebuildEnabled, nil)
 	if err != nil {
 		return err
@@ -252,12 +253,12 @@ func (pd *ProtectionDomain) SetRebuildEnabled(ID string, rebuildEnabledValue str
 }
 
 // SetRebuildRebalanceParallelismParam Sets rebuild/rebalance parallelism
-func (pd *ProtectionDomain) SetRebuildRebalanceParallelismParam(ID string, limitValue string) error {
+func (pd *ProtectionDomain) SetRebuildRebalanceParallelismParam(ctx context.Context, ID string, limitValue string) error {
 	rebuildRebalanceParam := &types.RebuildRebalanceParallelismParam{
 		Limit: limitValue,
 	}
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/setRebuildRebalanceParallelism", ID)
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, rebuildRebalanceParam, nil)
 	if err != nil {
 		return err
@@ -266,19 +267,19 @@ func (pd *ProtectionDomain) SetRebuildRebalanceParallelismParam(ID string, limit
 }
 
 // Fragmentation enables or disables fragmentation
-func (pd *ProtectionDomain) Fragmentation(ID string, value bool) error {
+func (pd *ProtectionDomain) Fragmentation(ctx context.Context, ID string, value bool) error {
 	payload := &types.FragmentationParam{}
 	if value {
 
 		path := fmt.Sprintf("/api/instances/StoragePool::%v/action/enableFragmentation", ID)
-		err := pd.client.getJSONWithRetry(
+		err := pd.client.getJSONWithRetry(ctx,
 			http.MethodPost, path, payload, nil)
 		if err != nil {
 			return err
 		}
 	} else {
 		path := fmt.Sprintf("/api/instances/StoragePool::%v/action/disableFragmentation", ID)
-		err := pd.client.getJSONWithRetry(
+		err := pd.client.getJSONWithRetry(ctx,
 			http.MethodPost, path, payload, nil)
 		if err != nil {
 			return err
@@ -289,13 +290,13 @@ func (pd *ProtectionDomain) Fragmentation(ID string, value bool) error {
 }
 
 // DisableRFCache Disables RFCache
-func (pd *ProtectionDomain) DisableRFCache(ID string) (string, error) {
+func (pd *ProtectionDomain) DisableRFCache(ctx context.Context, ID string) (string, error) {
 	payload := &types.StoragePoolUseRfCache{}
 
 	path := fmt.Sprintf("/api/instances/StoragePool::%v/action/disableRfcache", ID)
 
 	spResp := types.StoragePoolResp{}
-	err := pd.client.getJSONWithRetry(
+	err := pd.client.getJSONWithRetry(ctx,
 
 		http.MethodPost, path, payload, &spResp)
 	if err != nil {
@@ -306,9 +307,9 @@ func (pd *ProtectionDomain) DisableRFCache(ID string) (string, error) {
 }
 
 // DeleteStoragePool will delete a storage pool
-func (pd *ProtectionDomain) DeleteStoragePool(name string) error {
+func (pd *ProtectionDomain) DeleteStoragePool(ctx context.Context, name string) error {
 	// get the storage pool name
-	pool, err := pd.FindStoragePool("", name, "")
+	pool, err := pd.FindStoragePool(ctx, "", name, "")
 	if err != nil {
 		return err
 	}
@@ -322,7 +323,7 @@ func (pd *ProtectionDomain) DeleteStoragePool(name string) error {
 
 	path := fmt.Sprintf("%v/action/removeStoragePool", link.HREF)
 
-	err = pd.client.getJSONWithRetry(
+	err = pd.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, storagePoolParam, nil)
 	if err != nil {
 		return err
@@ -332,7 +333,7 @@ func (pd *ProtectionDomain) DeleteStoragePool(name string) error {
 }
 
 // GetStoragePool returns a storage pool
-func (pd *ProtectionDomain) GetStoragePool(
+func (pd *ProtectionDomain) GetStoragePool(ctx context.Context,
 	storagepoolhref string,
 ) ([]*types.StoragePool, error) {
 	var (
@@ -348,10 +349,10 @@ func (pd *ProtectionDomain) GetStoragePool(
 		if err != nil {
 			return nil, err
 		}
-		err = pd.client.getJSONWithRetry(
+		err = pd.client.getJSONWithRetry(ctx,
 			http.MethodGet, link.HREF, nil, &sps)
 	} else {
-		err = pd.client.getJSONWithRetry(
+		err = pd.client.getJSONWithRetry(ctx,
 			http.MethodGet, storagepoolhref, nil, sp)
 	}
 	if err != nil {
@@ -365,10 +366,10 @@ func (pd *ProtectionDomain) GetStoragePool(
 }
 
 // FindStoragePool returns a storagepool based on id or name
-func (pd *ProtectionDomain) FindStoragePool(
+func (pd *ProtectionDomain) FindStoragePool(ctx context.Context,
 	id, name, href string,
 ) (*types.StoragePool, error) {
-	sps, err := pd.GetStoragePool(href)
+	sps, err := pd.GetStoragePool(ctx, href)
 	if err != nil {
 		return nil, fmt.Errorf("Error getting protection domains %s", err)
 	}
@@ -383,7 +384,7 @@ func (pd *ProtectionDomain) FindStoragePool(
 }
 
 // GetStatistics returns statistics
-func (sp *StoragePool) GetStatistics() (*types.Statistics, error) {
+func (sp *StoragePool) GetStatistics(ctx context.Context) (*types.Statistics, error) {
 	link, err := GetLink(sp.StoragePool.Links,
 		"/api/StoragePool/relationship/Statistics")
 	if err != nil {
@@ -391,7 +392,7 @@ func (sp *StoragePool) GetStatistics() (*types.Statistics, error) {
 	}
 
 	stats := types.Statistics{}
-	err = sp.client.getJSONWithRetry(
+	err = sp.client.getJSONWithRetry(ctx,
 		http.MethodGet, link.HREF, nil, &stats)
 	if err != nil {
 		return nil, err
@@ -401,7 +402,7 @@ func (sp *StoragePool) GetStatistics() (*types.Statistics, error) {
 }
 
 // GetSDSStoragePool return SDS instances associated with storage pool
-func (sp *StoragePool) GetSDSStoragePool() ([]types.Sds, error) {
+func (sp *StoragePool) GetSDSStoragePool(ctx context.Context) ([]types.Sds, error) {
 	link, err := GetLink(sp.StoragePool.Links,
 		"/api/StoragePool/relationship/SpSds")
 	if err != nil {
@@ -409,7 +410,7 @@ func (sp *StoragePool) GetSDSStoragePool() ([]types.Sds, error) {
 	}
 
 	sds := []types.Sds{}
-	err = sp.client.getJSONWithRetry(
+	err = sp.client.getJSONWithRetry(ctx,
 		http.MethodGet, link.HREF, nil, &sds)
 	if err != nil {
 		return nil, err
@@ -419,13 +420,13 @@ func (sp *StoragePool) GetSDSStoragePool() ([]types.Sds, error) {
 }
 
 // GetStoragePoolByID returns a Storagepool by ID
-func (s *System) GetStoragePoolByID(id string) (*types.StoragePool, error) {
+func (s *System) GetStoragePoolByID(ctx context.Context, id string) (*types.StoragePool, error) {
 	defer TimeSpent("GetStoragePoolByID", time.Now())
 
 	path := fmt.Sprintf("/api/instances/StoragePool::%s", id)
 
 	var storagepool *types.StoragePool
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &storagepool)
 	if err != nil {
 		return nil, err
@@ -435,12 +436,12 @@ func (s *System) GetStoragePoolByID(id string) (*types.StoragePool, error) {
 }
 
 // GetAllStoragePools returns all Storage pools on the system
-func (s *System) GetAllStoragePools() ([]types.StoragePool, error) {
+func (s *System) GetAllStoragePools(ctx context.Context) ([]types.StoragePool, error) {
 	defer TimeSpent("GetStoragepool", time.Now())
 	path := "/api/types/StoragePool/instances"
 
 	var storagepools []types.StoragePool
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &storagepools)
 	if err != nil {
 		return nil, err

--- a/system.go
+++ b/system.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -35,10 +36,10 @@ func NewSystem(client *Client) *System {
 }
 
 // GetSystems returns systems
-func (c *Client) GetSystems() ([]*types.System, error) {
+func (c *Client) GetSystems(ctx context.Context) ([]*types.System, error) {
 	defer TimeSpent("GetSystems", time.Now())
 
-	systems, err := c.GetInstance("")
+	systems, err := c.GetInstance(ctx, "")
 	if err != nil {
 		return nil, fmt.Errorf("err: problem getting instances: %s", err)
 	}
@@ -46,12 +47,12 @@ func (c *Client) GetSystems() ([]*types.System, error) {
 }
 
 // FindSystem returns a system based on ID or name
-func (c *Client) FindSystem(
+func (c *Client) FindSystem(ctx context.Context,
 	instanceID, name, href string,
 ) (*System, error) {
 	defer TimeSpent("FindSystem", time.Now())
 
-	systems, err := c.GetInstance(href)
+	systems, err := c.GetInstance(ctx, href)
 	if err != nil {
 		return nil, fmt.Errorf("err: problem getting instances: %s", err)
 	}
@@ -67,7 +68,7 @@ func (c *Client) FindSystem(
 }
 
 // GetStatistics returns system statistics
-func (s *System) GetStatistics() (*types.Statistics, error) {
+func (s *System) GetStatistics(ctx context.Context) (*types.Statistics, error) {
 	defer TimeSpent("GetStatistics", time.Now())
 
 	link, err := GetLink(s.System.Links,
@@ -77,7 +78,7 @@ func (s *System) GetStatistics() (*types.Statistics, error) {
 	}
 
 	stats := types.Statistics{}
-	err = s.client.getJSONWithRetry(
+	err = s.client.getJSONWithRetry(ctx,
 		http.MethodGet, link.HREF, nil, &stats)
 	if err != nil {
 		return nil, err
@@ -87,7 +88,7 @@ func (s *System) GetStatistics() (*types.Statistics, error) {
 }
 
 // CreateSnapshotConsistencyGroup creates a snapshot consistency group
-func (s *System) CreateSnapshotConsistencyGroup(
+func (s *System) CreateSnapshotConsistencyGroup(ctx context.Context,
 	snapshotVolumesParam *types.SnapshotVolumesParam,
 ) (*types.SnapshotVolumesResp, error) {
 	defer TimeSpent("CreateSnapshotConsistencyGroup", time.Now())
@@ -100,7 +101,7 @@ func (s *System) CreateSnapshotConsistencyGroup(
 	path := fmt.Sprintf("%v/action/snapshotVolumes", link.HREF)
 
 	snapResp := types.SnapshotVolumesResp{}
-	err = s.client.getJSONWithRetry(
+	err = s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, snapshotVolumesParam, &snapResp)
 	if err != nil {
 		return nil, err
@@ -110,14 +111,14 @@ func (s *System) CreateSnapshotConsistencyGroup(
 }
 
 // GetMDMClusterDetails returns MDM cluster details
-func (s *System) GetMDMClusterDetails() (*types.MdmCluster, error) {
+func (s *System) GetMDMClusterDetails(ctx context.Context) (*types.MdmCluster, error) {
 	defer TimeSpent("GetMDMClusterDetails", time.Now())
 
 	path := "api/instances/System/queryMdmCluster"
 	mdmParam := &types.EmptyPayload{}
 
 	mdmResp := types.MdmCluster{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, mdmParam, &mdmResp)
 	if err != nil {
 		return nil, err
@@ -127,12 +128,12 @@ func (s *System) GetMDMClusterDetails() (*types.MdmCluster, error) {
 }
 
 // AddStandByMdm adds the standby MDMs to the MDM cluster
-func (s *System) AddStandByMdm(mdmParam *types.StandByMdm) (string, error) {
+func (s *System) AddStandByMdm(ctx context.Context, mdmParam *types.StandByMdm) (string, error) {
 	defer TimeSpent("AddStandByMdm", time.Now())
 
 	path := "api/instances/System/action/addStandbyMdm"
 	mdm := &types.Mdm{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, mdmParam, &mdm)
 	if err != nil {
 		return "", err
@@ -141,14 +142,14 @@ func (s *System) AddStandByMdm(mdmParam *types.StandByMdm) (string, error) {
 }
 
 // RemoveStandByMdm removes standby MDM
-func (s *System) RemoveStandByMdm(id string) error {
+func (s *System) RemoveStandByMdm(ctx context.Context, id string) error {
 	defer TimeSpent("RemoveStandByMdm", time.Now())
 
 	path := "/api/instances/System/action/removeStandbyMdm"
 	mdmParam := &types.RemoveStandByMdmParam{
 		ID: id,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, mdmParam, nil)
 	if err != nil {
 		return err
@@ -157,14 +158,14 @@ func (s *System) RemoveStandByMdm(id string) error {
 }
 
 // ModifyPerformanceProfileMdmCluster modifies performance profile of MDM cluster
-func (s *System) ModifyPerformanceProfileMdmCluster(perfProfile string) error {
+func (s *System) ModifyPerformanceProfileMdmCluster(ctx context.Context, perfProfile string) error {
 	defer TimeSpent("ModifyPerformanceProfileMdmCluster", time.Now())
 
 	path := "/api/instances/System/action/setMdmPerformanceParameters"
 	mdmParam := &types.ChangeMdmPerfProfile{
 		PerfProfile: perfProfile,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, mdmParam, nil)
 	if err != nil {
 		return err
@@ -173,12 +174,12 @@ func (s *System) ModifyPerformanceProfileMdmCluster(perfProfile string) error {
 }
 
 // SwitchClusterMode changes the MDM cluster mode
-func (s *System) SwitchClusterMode(switchClusterMode *types.SwitchClusterMode) error {
+func (s *System) SwitchClusterMode(ctx context.Context, switchClusterMode *types.SwitchClusterMode) error {
 	defer TimeSpent("SwitchClusterMode", time.Now())
 
 	path := "/api/instances/System/action/switchClusterMode"
 
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, switchClusterMode, nil)
 	if err != nil {
 		return err
@@ -187,14 +188,14 @@ func (s *System) SwitchClusterMode(switchClusterMode *types.SwitchClusterMode) e
 }
 
 // ChangeMdmOwnerShip modifies the primary MDM
-func (s *System) ChangeMdmOwnerShip(id string) error {
+func (s *System) ChangeMdmOwnerShip(ctx context.Context, id string) error {
 	defer TimeSpent("ChangeMdmOwnerShip", time.Now())
 
 	path := "/api/instances/System/action/changeMdmOwnership"
 	mdmParam := &types.ChangeMdmOwnerShip{
 		ID: id,
 	}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, mdmParam, nil)
 	if err != nil {
 		return err
@@ -203,11 +204,11 @@ func (s *System) ChangeMdmOwnerShip(id string) error {
 }
 
 // RenameMdm modifies name of the MDM
-func (s *System) RenameMdm(renameMdm *types.RenameMdm) error {
+func (s *System) RenameMdm(ctx context.Context, renameMdm *types.RenameMdm) error {
 	defer TimeSpent("ChangeMdmOwnerShip", time.Now())
 
 	path := "/api/instances/System/action/renameMdm"
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, renameMdm, nil)
 	if err != nil {
 		return err

--- a/system_limit.go
+++ b/system_limit.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"time"
@@ -21,11 +22,11 @@ import (
 )
 
 // GetSystemLimits gets list of sytem limits
-func (c *Client) GetSystemLimits() (systemLimits *types.QuerySystemLimitsResponse, err error) {
+func (c *Client) GetSystemLimits(ctx context.Context) (systemLimits *types.QuerySystemLimitsResponse, err error) {
 	defer TimeSpent("GetSystemLimits", time.Now())
 	var body types.QuerySystemLimitsParam
 	path := "/api/instances/System/action/querySystemLimits"
-	err = c.getJSONWithRetry(
+	err = c.getJSONWithRetry(ctx,
 		http.MethodPost, path, body, &systemLimits)
 	if err != nil {
 		return nil, err
@@ -35,9 +36,9 @@ func (c *Client) GetSystemLimits() (systemLimits *types.QuerySystemLimitsRespons
 }
 
 // GetMaxVol returns max volume size in GB
-func (c *Client) GetMaxVol() (MaxVolumeSize string, err error) {
+func (c *Client) GetMaxVol(ctx context.Context) (MaxVolumeSize string, err error) {
 	defer TimeSpent("GetMaxVol", time.Now())
-	sysLimit, err := c.GetSystemLimits()
+	sysLimit, err := c.GetSystemLimits(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/system_limit_test.go
+++ b/system_limit_test.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -136,7 +137,7 @@ func TestGetSystemLimits(t *testing.T) {
 				client: client,
 			}
 
-			resp, err := sys.client.GetSystemLimits()
+			resp, err := sys.client.GetSystemLimits(context.Background())
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}

--- a/system_test.go
+++ b/system_test.go
@@ -1,6 +1,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"math"
 	"net/http"
@@ -45,7 +46,7 @@ func TestModifyPerformanceProfile(t *testing.T) {
 				client: client,
 			}
 
-			err = s.ModifyPerformanceProfileMdmCluster(tc.perfProfile)
+			err = s.ModifyPerformanceProfileMdmCluster(context.Background(), tc.perfProfile)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Modifying performance profile of MDM cluster did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)
@@ -94,7 +95,7 @@ func TestAddStandByMDM(t *testing.T) {
 				IPs:  tc.ips,
 				Role: tc.role,
 			}
-			_, err = s.AddStandByMdm(&payload)
+			_, err = s.AddStandByMdm(context.Background(), &payload)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Adding standby mdm did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)
@@ -142,7 +143,7 @@ func TestRemoveStandByMDM(t *testing.T) {
 				client: client,
 			}
 
-			err = s.RemoveStandByMdm(tc.mdmID)
+			err = s.RemoveStandByMdm(context.Background(), tc.mdmID)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Adding standby mdm did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)
@@ -190,7 +191,7 @@ func TestChangeMDMOwnership(t *testing.T) {
 				client: client,
 			}
 
-			err = s.ChangeMdmOwnerShip(tc.mdmID)
+			err = s.ChangeMdmOwnerShip(context.Background(), tc.mdmID)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Changing MDM ownership did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)
@@ -249,7 +250,7 @@ func TestSwitchClusterMode(t *testing.T) {
 				AddTBMdms:        tc.addTBMdmList,
 			}
 
-			err = s.SwitchClusterMode(&payload)
+			err = s.SwitchClusterMode(context.Background(), &payload)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Switching MDM cluster did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)
@@ -279,7 +280,7 @@ func TestGetMDMClusterDetails(t *testing.T) {
 		client: client,
 	}
 
-	mdmDetails, err1 := s.GetMDMClusterDetails()
+	mdmDetails, err1 := s.GetMDMClusterDetails(context.Background())
 	assert.NotNil(t, mdmDetails)
 	assert.Nil(t, err1)
 }
@@ -327,7 +328,7 @@ func TestRenameMdm(t *testing.T) {
 				NewName: tc.newName,
 			}
 
-			err = s.RenameMdm(&payload)
+			err = s.RenameMdm(context.Background(), &payload)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Renaming MDM did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)

--- a/tree_quota.go
+++ b/tree_quota.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -22,11 +23,11 @@ import (
 )
 
 // GetTreeQuota gets list of tree Quota
-func (s *System) GetTreeQuota() (treeQuotaList []types.TreeQuota, err error) {
+func (s *System) GetTreeQuota(ctx context.Context) (treeQuotaList []types.TreeQuota, err error) {
 	defer TimeSpent("GetTreeQuota", time.Now())
 	path := fmt.Sprintf("/rest/v1/file-tree-quotas?select=*")
 
-	err = s.client.getJSONWithRetry(
+	err = s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &treeQuotaList)
 	if err != nil {
 		return nil, err
@@ -36,11 +37,11 @@ func (s *System) GetTreeQuota() (treeQuotaList []types.TreeQuota, err error) {
 }
 
 // GetTreeQuotaByID gets a specific tree quota by ID
-func (s *System) GetTreeQuotaByID(id string) (treeQuota *types.TreeQuota, err error) {
+func (s *System) GetTreeQuotaByID(ctx context.Context, id string) (treeQuota *types.TreeQuota, err error) {
 	defer TimeSpent("GetTreeQuota", time.Now())
 	path := fmt.Sprintf("/rest/v1/file-tree-quotas/%s?select=*", id)
 
-	err = s.client.getJSONWithRetry(
+	err = s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &treeQuota)
 	if err != nil {
 		return nil, err
@@ -50,11 +51,11 @@ func (s *System) GetTreeQuotaByID(id string) (treeQuota *types.TreeQuota, err er
 }
 
 // CreateTreeQuota create an tree quota for a File System.
-func (s *System) CreateTreeQuota(createParams *types.TreeQuotaCreate) (resp *types.TreeQuotaCreateResponse, err error) {
+func (s *System) CreateTreeQuota(ctx context.Context, createParams *types.TreeQuotaCreate) (resp *types.TreeQuotaCreateResponse, err error) {
 	path := fmt.Sprintf("/rest/v1/file-tree-quotas")
 
 	var body *types.TreeQuotaCreate = createParams
-	err = s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)
+	err = s.client.getJSONWithRetry(ctx, http.MethodPost, path, body, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -63,11 +64,11 @@ func (s *System) CreateTreeQuota(createParams *types.TreeQuotaCreate) (resp *typ
 }
 
 // ModifyTreeQuota modifies a tree quota
-func (s *System) ModifyTreeQuota(ModifyParams *types.TreeQuotaModify, id string) (err error) {
+func (s *System) ModifyTreeQuota(ctx context.Context, ModifyParams *types.TreeQuotaModify, id string) (err error) {
 	path := fmt.Sprintf("/rest/v1/file-tree-quotas/%s", id)
 
 	var body *types.TreeQuotaModify = ModifyParams
-	err = s.client.getJSONWithRetry(http.MethodPatch, path, body, nil)
+	err = s.client.getJSONWithRetry(ctx, http.MethodPatch, path, body, nil)
 	if err != nil {
 		return err
 	}
@@ -76,11 +77,11 @@ func (s *System) ModifyTreeQuota(ModifyParams *types.TreeQuotaModify, id string)
 }
 
 // DeleteTreeQuota delete a tree quota by ID
-func (s *System) DeleteTreeQuota(id string) error {
+func (s *System) DeleteTreeQuota(ctx context.Context, id string) error {
 	defer TimeSpent("DeleteTreeQuota", time.Now())
 	path := fmt.Sprintf("/rest/v1/file-tree-quotas/%s", id)
 
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodDelete, path, nil, nil)
 	if err != nil {
 		return err
@@ -90,9 +91,9 @@ func (s *System) DeleteTreeQuota(id string) error {
 }
 
 // GetTreeQuotaByFSID gets a specific tree quota by filesystem ID
-func (s *System) GetTreeQuotaByFSID(id string) (*types.TreeQuota, error) {
+func (s *System) GetTreeQuotaByFSID(ctx context.Context, id string) (*types.TreeQuota, error) {
 	defer TimeSpent("GetTreeQuotaByFSID", time.Now())
-	treeQuotaList, err := s.GetTreeQuota()
+	treeQuotaList, err := s.GetTreeQuota(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/tree_quota_test.go
+++ b/tree_quota_test.go
@@ -19,6 +19,7 @@
 package goscaleio
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -118,7 +119,7 @@ func TestTreeQuotaByID(t *testing.T) {
 				client: client,
 			}
 
-			resp, err := s.GetTreeQuotaByID(testCaseIDs[id])
+			resp, err := s.GetTreeQuotaByID(context.Background(), testCaseIDs[id])
 			for _, checkFn := range checkFns {
 				checkFn(t, resp, err)
 			}
@@ -206,7 +207,7 @@ func TestCreateTreeQuota(t *testing.T) {
 				client: client,
 			}
 
-			resp, err := s.CreateTreeQuota(&types.TreeQuotaCreate{
+			resp, err := s.CreateTreeQuota(context.Background(), &types.TreeQuotaCreate{
 				FileSystemID: "64b3ceca-046f-eb3a-da83-3a7645b0a943",
 				Path:         "/fs111",
 			})
@@ -236,7 +237,7 @@ func TestDeleteTreeQuota(t *testing.T) {
 		client: client,
 	}
 
-	err = s.DeleteTreeQuota(id)
+	err = s.DeleteTreeQuota(context.Background(), id)
 	assert.Nil(t, err)
 }
 
@@ -283,7 +284,7 @@ func TestModifyTreeQuota(t *testing.T) {
 			}
 
 			// calling ModifyTreeQuota with mock value
-			err = s.ModifyTreeQuota(quotaParam, tc.QuotaID)
+			err = s.ModifyTreeQuota(context.Background(), quotaParam, tc.QuotaID)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Modifying FS did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)

--- a/user.go
+++ b/user.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -22,14 +23,14 @@ import (
 )
 
 // GetUser returns user
-func (s *System) GetUser() ([]types.User, error) {
+func (s *System) GetUser(ctx context.Context) ([]types.User, error) {
 	defer TimeSpent("GetUser", time.Now())
 
 	path := fmt.Sprintf("/api/instances/System::%v/relationships/User",
 		s.System.ID)
 
 	var user []types.User
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodGet, path, nil, &user)
 	if err != nil {
 		return nil, err
@@ -39,7 +40,7 @@ func (s *System) GetUser() ([]types.User, error) {
 }
 
 // GetUserByIDName returns a specific user based on it's user id
-func (s *System) GetUserByIDName(userID string, username string) (*types.User, error) {
+func (s *System) GetUserByIDName(ctx context.Context, userID string, username string) (*types.User, error) {
 	if userID == "" && username == "" {
 		return nil, errors.New("user name or ID is mandatory, please enter a valid value")
 	}
@@ -47,7 +48,7 @@ func (s *System) GetUserByIDName(userID string, username string) (*types.User, e
 	if userID != "" {
 		path := fmt.Sprintf("/api/instances/User::%v", userID)
 		user := &types.User{}
-		err := s.client.getJSONWithRetry(http.MethodGet, path, nil, &user)
+		err := s.client.getJSONWithRetry(ctx, http.MethodGet, path, nil, &user)
 		if err != nil {
 			return nil, err
 		}
@@ -56,7 +57,7 @@ func (s *System) GetUserByIDName(userID string, username string) (*types.User, e
 
 	}
 	// Get user by username
-	allUsers, err := s.GetUser()
+	allUsers, err := s.GetUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -71,9 +72,9 @@ func (s *System) GetUserByIDName(userID string, username string) (*types.User, e
 }
 
 // CreateUser creates a new user with some role.
-func (s *System) CreateUser(userParam *types.UserParam) (*types.UserResp, error) {
+func (s *System) CreateUser(ctx context.Context, userParam *types.UserParam) (*types.UserResp, error) {
 	userResp := &types.UserResp{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, "/api/types/User/instances", userParam, &userResp)
 	if err != nil {
 		return nil, err
@@ -82,18 +83,18 @@ func (s *System) CreateUser(userParam *types.UserParam) (*types.UserResp, error)
 }
 
 // RemoveUser removes a particular user.
-func (s *System) RemoveUser(userID string) error {
+func (s *System) RemoveUser(ctx context.Context, userID string) error {
 	path := fmt.Sprintf("/api/instances/User::%v/action/removeUser", userID)
 	empty := &types.EmptyPayload{}
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, empty, nil)
 	return err
 }
 
 // SetUserRole sets a new role for a particular user.
-func (s *System) SetUserRole(userRole *types.UserRoleParam, userID string) error {
+func (s *System) SetUserRole(ctx context.Context, userRole *types.UserRoleParam, userID string) error {
 	path := fmt.Sprintf("/api/instances/User::%v/action/setUserRole", userID)
-	err := s.client.getJSONWithRetry(
+	err := s.client.getJSONWithRetry(ctx,
 		http.MethodPost, path, userRole, nil)
 	return err
 }

--- a/user_test.go
+++ b/user_test.go
@@ -1,6 +1,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"math"
 	"net/http"
@@ -48,7 +49,7 @@ func TestCreateUser(t *testing.T) {
 			s := System{
 				client: client,
 			}
-			_, err2 := s.CreateUser(&tc.user)
+			_, err2 := s.CreateUser(context.Background(), &tc.user)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Creating User did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -95,7 +96,7 @@ func TestGetUserByIDName(t *testing.T) {
 			s := System{
 				client: client,
 			}
-			_, err2 := s.GetUserByIDName(tc.id, tc.name)
+			_, err2 := s.GetUserByIDName(context.Background(), tc.id, tc.name)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Creating User did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -139,7 +140,7 @@ func TestRemoveUser(t *testing.T) {
 			s := System{
 				client: client,
 			}
-			err2 := s.RemoveUser(tc.id)
+			err2 := s.RemoveUser(context.Background(), tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Removing User did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)
@@ -190,7 +191,7 @@ func TestSetRole(t *testing.T) {
 			s := System{
 				client: client,
 			}
-			err2 := s.SetUserRole(&tc.role, tc.id)
+			err2 := s.SetUserRole(context.Background(), &tc.role, tc.id)
 			if err2 != nil {
 				if tc.expected == nil {
 					t.Errorf("Removing User did not work as expected, \n\tgot: %s \n\twant: %v", err2, tc.expected)

--- a/volume_test.go
+++ b/volume_test.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -126,7 +127,7 @@ func Test_GetVolumeStatistics(t *testing.T) {
 
 			volClient := NewVolume(client)
 			volClient.Volume = vol
-			_, err = volClient.GetVolumeStatistics()
+			_, err = volClient.GetVolumeStatistics(context.Background())
 			for _, checkFn := range checkFns {
 				checkFn(t, err)
 			}

--- a/vtree.go
+++ b/vtree.go
@@ -13,6 +13,7 @@
 package goscaleio
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -21,13 +22,13 @@ import (
 )
 
 // GetVTrees returns vtrees present in the cluster
-func (c *Client) GetVTrees() ([]types.VTreeDetails, error) {
+func (c *Client) GetVTrees(ctx context.Context) ([]types.VTreeDetails, error) {
 	defer TimeSpent("GetVTrees", time.Now())
 
 	path := "/api/types/VTree/instances"
 
 	var vTree []types.VTreeDetails
-	err := c.getJSONWithRetry(http.MethodGet, path, nil, &vTree)
+	err := c.getJSONWithRetry(ctx, http.MethodGet, path, nil, &vTree)
 	if err != nil {
 		return nil, err
 	}
@@ -36,13 +37,13 @@ func (c *Client) GetVTrees() ([]types.VTreeDetails, error) {
 }
 
 // GetVTreeByID returns the VTree details for the given ID
-func (c *Client) GetVTreeByID(id string) (*types.VTreeDetails, error) {
+func (c *Client) GetVTreeByID(ctx context.Context, id string) (*types.VTreeDetails, error) {
 	defer TimeSpent("GetVTreeByID", time.Now())
 
 	path := fmt.Sprintf("/api/instances/VTree::%v", id)
 
 	var vTree types.VTreeDetails
-	err := c.getJSONWithRetry(http.MethodGet, path, nil, &vTree)
+	err := c.getJSONWithRetry(ctx, http.MethodGet, path, nil, &vTree)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +51,7 @@ func (c *Client) GetVTreeByID(id string) (*types.VTreeDetails, error) {
 }
 
 // GetVTreeInstances returns the VTree details for the given IDs
-func (c *Client) GetVTreeInstances(ids []string) ([]types.VTreeDetails, error) {
+func (c *Client) GetVTreeInstances(ctx context.Context, ids []string) ([]types.VTreeDetails, error) {
 	defer TimeSpent("GetVTrees", time.Now())
 
 	path := "/api/types/VTree/instances/action/queryBySelectedIds"
@@ -59,7 +60,7 @@ func (c *Client) GetVTreeInstances(ids []string) ([]types.VTreeDetails, error) {
 		IDs: ids,
 	}
 	var vTree []types.VTreeDetails
-	err := c.getJSONWithRetry(http.MethodPost, path, payload, &vTree)
+	err := c.getJSONWithRetry(ctx, http.MethodPost, path, payload, &vTree)
 	if err != nil {
 		return nil, err
 	}
@@ -67,13 +68,13 @@ func (c *Client) GetVTreeInstances(ids []string) ([]types.VTreeDetails, error) {
 }
 
 // GetVTreeByVolumeID returns VTree details based on Volume ID
-func (c *Client) GetVTreeByVolumeID(id string) (*types.VTreeDetails, error) {
+func (c *Client) GetVTreeByVolumeID(ctx context.Context, id string) (*types.VTreeDetails, error) {
 	defer TimeSpent("GetVTreeByVolumeID", time.Now())
 
-	volDetails, err := c.GetVolume("", id, "", "", false)
+	volDetails, err := c.GetVolume(ctx, "", id, "", "", false)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.GetVTreeByID(volDetails[0].VTreeID)
+	return c.GetVTreeByID(ctx, volDetails[0].VTreeID)
 }

--- a/vtree_test.go
+++ b/vtree_test.go
@@ -1,6 +1,7 @@
 package goscaleio
 
 import (
+	"context"
 	"errors"
 	"math"
 	"net/http"
@@ -22,7 +23,7 @@ func TestGetVTrees(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vTreeDetails, err := client.GetVTrees()
+	vTreeDetails, err := client.GetVTrees(context.Background())
 	assert.Equal(t, len(vTreeDetails), 0)
 	assert.Nil(t, err)
 }
@@ -56,7 +57,7 @@ func TestGetVTreeByID(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = client.GetVTreeByID(tc.id)
+			_, err = client.GetVTreeByID(context.Background(), tc.id)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Getting VTree by ID did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)
@@ -99,7 +100,7 @@ func TestGetVTreeInstances(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = client.GetVTreeInstances(tc.ids)
+			_, err = client.GetVTreeInstances(context.Background(), tc.ids)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Getting VTree by ID did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)
@@ -142,7 +143,7 @@ func TestGetVTreeByVolumeID(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			_, err = client.GetVTreeByVolumeID(tc.id)
+			_, err = client.GetVTreeByVolumeID(context.Background(), tc.id)
 			if err != nil {
 				if tc.expected == nil {
 					t.Errorf("Getting VTree by Volume ID did not work as expected, \n\tgot: %s \n\twant: %v", err, tc.expected)


### PR DESCRIPTION
# Description
Propagate through the `context` to all calls that will ultimately make and `http` request. Previously, we were not passing it through and therefore, not adhering to the deadline that was associated with the context. This could/would result in context expiring but the http request having no concept of this and could/would cause things to get out of sync.

Also, due to an extremely low coverage in unit tests, this PR will contain the unit tests to increase to the necessary thresholds.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage - Not Yet..
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ensure all unit tests are still passing correctly.
