### PR TITLE
Add WithContext to the Client

### DIFF
--- a/api.go
+++ b/api.go
@@ -66,16 +66,13 @@ type ConfigConnect struct {
 	Insecure bool
 }
 
-// ClientPersistent defines struct for ClientPersistent
-type ClientPersistent struct {
-	configConnect *ConfigConnect
-	client        *Client
-}
-
 // GetVersion returns version
 func (c *Client) GetVersion() (string, error) {
+	ctx := c.GetContext()
+	defer c.ResetContext()
+
 	resp, err := c.api.DoAndGetResponseBody(
-		context.Background(), http.MethodGet, "/api/version", nil, nil, c.configConnect.Version)
+		ctx, http.MethodGet, "/api/version", nil, nil, c.configConnect.Version)
 	if err != nil {
 		return "", err
 	}
@@ -94,7 +91,7 @@ func (c *Client) GetVersion() (string, error) {
 			return "", err
 		}
 		resp, err = c.api.DoAndGetResponseBody(
-			context.Background(), http.MethodGet, "/api/version", nil, nil, c.configConnect.Version)
+			ctx, http.MethodGet, "/api/version", nil, nil, c.configConnect.Version)
 		if err != nil {
 			return "", err
 		}
@@ -200,8 +197,11 @@ func (c *Client) getJSONWithRetry(
 	headers[api.HeaderKeyContentType] = conHeader
 	addMetaData(headers, body)
 
+	ctx := c.GetContext()
+	defer c.ResetContext()
+
 	err := c.api.DoWithHeaders(
-		context.Background(), method, uri, headers, body, resp, c.configConnect.Version)
+		ctx, method, uri, headers, body, resp, c.configConnect.Version)
 	if err == nil {
 		return nil
 	}
@@ -216,7 +216,7 @@ func (c *Client) getJSONWithRetry(
 				return fmt.Errorf("Error Authenticating: %s", err)
 			}
 			return c.api.DoWithHeaders(
-				context.Background(), method, uri, headers, body, resp, c.configConnect.Version)
+				ctx, method, uri, headers, body, resp, c.configConnect.Version)
 		}
 	}
 	doLog(logger.Error, err.Error())
@@ -253,6 +253,9 @@ func (c *Client) getStringWithRetry(
 	headers[api.HeaderKeyContentType] = conHeader
 	addMetaData(headers, body)
 
+	ctx := c.GetContext()
+	defer c.ResetContext()
+
 	checkResponse := func(resp *http.Response) (string, bool, error) {
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
@@ -279,7 +282,7 @@ func (c *Client) getStringWithRetry(
 	}
 
 	resp, err := c.api.DoAndGetResponseBody(
-		context.Background(), method, uri, headers, body, c.configConnect.Version)
+		ctx, method, uri, headers, body, c.configConnect.Version)
 	if err != nil {
 		return "", err
 	}
@@ -292,7 +295,7 @@ func (c *Client) getStringWithRetry(
 				return "", fmt.Errorf("Error Authenticating: %s", err)
 			}
 			resp, err = c.api.DoAndGetResponseBody(
-				context.Background(), method, uri, headers, body, c.configConnect.Version)
+				ctx, method, uri, headers, body, c.configConnect.Version)
 			if err != nil {
 				return "", err
 			}

--- a/api.go
+++ b/api.go
@@ -49,6 +49,7 @@ var (
 
 // Client defines struct for Client
 type Client struct {
+	ctx           context.Context
 	configConnect *ConfigConnect
 	api           api.Client
 }
@@ -146,7 +147,9 @@ func (c *Client) Authenticate(configConnect *ConfigConnect) (Cluster, error) {
 		configConnect.Username, configConnect.Password)
 
 	resp, err := c.api.DoAndGetResponseBody(
-		context.Background(), http.MethodGet, "api/login", headers, nil, c.configConnect.Version)
+		c.GetContext(), http.MethodGet, "api/login", headers, nil, c.configConnect.Version)
+	defer c.ResetContext()
+
 	if err != nil {
 		doLog(logger.Error, err.Error())
 		return Cluster{}, err
@@ -315,6 +318,23 @@ func (c *Client) GetToken() string {
 // GetConfigConnect returns Config of client
 func (c *Client) GetConfigConnect() *ConfigConnect {
 	return c.configConnect
+}
+
+func (c *Client) WithContext(ctx context.Context) *Client {
+	c.ctx = ctx
+	return c
+}
+
+func (c *Client) GetContext() context.Context {
+	if c.ctx == nil {
+		return context.Background()
+	}
+
+	return c.ctx
+}
+
+func (c *Client) ResetContext() {
+	c.ctx = nil
 }
 
 // NewClient returns a new client

--- a/api.go
+++ b/api.go
@@ -148,7 +148,6 @@ func (c *Client) Authenticate(configConnect *ConfigConnect) (Cluster, error) {
 
 	resp, err := c.api.DoAndGetResponseBody(
 		ctx, http.MethodGet, "api/login", headers, nil, c.configConnect.Version)
-
 	if err != nil {
 		doLog(logger.Error, err.Error())
 		return Cluster{}, err

--- a/api.go
+++ b/api.go
@@ -68,8 +68,7 @@ type ConfigConnect struct {
 
 // GetVersion returns version
 func (c *Client) GetVersion() (string, error) {
-	ctx := c.GetContext()
-	defer c.ResetContext()
+	ctx := c.Context()
 
 	resp, err := c.api.DoAndGetResponseBody(
 		ctx, http.MethodGet, "/api/version", nil, nil, c.configConnect.Version)
@@ -144,8 +143,7 @@ func (c *Client) Authenticate(configConnect *ConfigConnect) (Cluster, error) {
 		configConnect.Username, configConnect.Password)
 
 	resp, err := c.api.DoAndGetResponseBody(
-		c.GetContext(), http.MethodGet, "api/login", headers, nil, c.configConnect.Version)
-	defer c.ResetContext()
+		c.Context(), http.MethodGet, "api/login", headers, nil, c.configConnect.Version)
 
 	if err != nil {
 		doLog(logger.Error, err.Error())
@@ -197,8 +195,7 @@ func (c *Client) getJSONWithRetry(
 	headers[api.HeaderKeyContentType] = conHeader
 	addMetaData(headers, body)
 
-	ctx := c.GetContext()
-	defer c.ResetContext()
+	ctx := c.Context()
 
 	err := c.api.DoWithHeaders(
 		ctx, method, uri, headers, body, resp, c.configConnect.Version)
@@ -253,8 +250,7 @@ func (c *Client) getStringWithRetry(
 	headers[api.HeaderKeyContentType] = conHeader
 	addMetaData(headers, body)
 
-	ctx := c.GetContext()
-	defer c.ResetContext()
+	ctx := c.Context()
 
 	checkResponse := func(resp *http.Response) (string, bool, error) {
 		defer func() {
@@ -324,20 +320,18 @@ func (c *Client) GetConfigConnect() *ConfigConnect {
 }
 
 func (c *Client) WithContext(ctx context.Context) *Client {
-	c.ctx = ctx
-	return c
+	c2 := new(Client)
+	*c2 = *c
+	c2.ctx = ctx
+	return c2
 }
 
-func (c *Client) GetContext() context.Context {
-	if c.ctx == nil {
-		return context.Background()
+func (c *Client) Context() context.Context {
+	if c.ctx != nil {
+		return c.ctx
 	}
 
-	return c.ctx
-}
-
-func (c *Client) ResetContext() {
-	c.ctx = nil
+	return context.Background()
 }
 
 // NewClient returns a new client

--- a/api_test.go
+++ b/api_test.go
@@ -561,11 +561,11 @@ func TestWithContext(t *testing.T) {
 	}
 
 	parentCtx := context.Background()
-	context, cancel := context.WithTimeout(parentCtx, 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Millisecond)
 	defer cancel()
 
 	// Test with Context
-	_, err = client.WithContext(context).Authenticate(&ConfigConnect{
+	_, err = client.WithContext(ctx).Authenticate(&ConfigConnect{
 		Username: "ScaleIOUser",
 		Password: "password",
 		Endpoint: "",

--- a/api_test.go
+++ b/api_test.go
@@ -561,7 +561,7 @@ func TestWithContext(t *testing.T) {
 	}
 
 	parentCtx := context.Background()
-	context, cancel := context.WithTimeout(parentCtx, 1*time.Second)
+	context, cancel := context.WithTimeout(parentCtx, 10*time.Millisecond)
 	defer cancel()
 
 	// Test with Context
@@ -575,7 +575,8 @@ func TestWithContext(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(2 * time.Second)
+	// Delay to test calls without context paramter set.
+	time.Sleep(1 * time.Second)
 
 	// Test with without context
 	_, err = client.Authenticate(&ConfigConnect{
@@ -587,5 +588,4 @@ func TestWithContext(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }

--- a/api_test.go
+++ b/api_test.go
@@ -542,6 +542,7 @@ func TestGetStringWithRetry(t *testing.T) {
 		})
 	}
 }
+
 func TestWithContext(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		switch req.RequestURI {

--- a/nfs.go
+++ b/nfs.go
@@ -66,7 +66,7 @@ func (s *System) GetNASByIDName(id string, name string) (*types.NAS, error) {
 	err := s.client.getJSONWithRetry(
 		http.MethodGet, path, nil, &nasList)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not find NAS server by name: %s, err: %s", name, err.Error())
 	}
 
 	name = strings.ToLower(name)


### PR DESCRIPTION
# Description
Add the ability to chain `WithContext` to Client api calls. This allows us to pass through the parent context that will be used to satisfy the timeouts of each `http` call.

**Note:** The context is not forced to be passed through on every call to limit the API changes throughout. It is up to the user to chain the context whenever it is needed.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1559 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 80% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Add unit tests with chaining the context and ensuring that we do not hit a `context deadline` in subsequent calls.
- [x] Adopted, where needed, the `WithContext` chaining in the PowerFlex driver where we were seeing a `context deadline`.

