### PR TITLE
Fix GET specific Resource Credential Model

### DIFF
--- a/resource_credentials.go
+++ b/resource_credentials.go
@@ -43,13 +43,13 @@ func (s *System) GetResourceCredentials() (*types.ResourceCredentials, error) {
 }
 
 // GetResourceCredential returns a specific credential using resource credential ID
-func (s *System) GetResourceCredential(id string) (*types.CredObj, error) {
+func (s *System) GetResourceCredential(id string) (*types.ResourceCredential, error) {
 	defer TimeSpent("GetResourceCredential", time.Now())
 
 	path := fmt.Sprintf(
 		"/api/v1/Credential/%v", id)
 
-	var credentialResult types.CredObj
+	var credentialResult types.ResourceCredential
 	err := s.client.getJSONWithRetry(
 		http.MethodGet, path, nil, &credentialResult)
 	if err != nil {


### PR DESCRIPTION
# Description

- GET Resource Credential by id was not using the correct model which caused an empty model with nil values to be return instead of the full object.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] UT
- [x] Integration Test

