### PR TITLE
Eliminated /noderoot mount, using a more specific mounted path for drv_cfg

### DIFF
--- a/drv_cfg.go
+++ b/drv_cfg.go
@@ -38,7 +38,7 @@ const (
 	IOCTLDevice = "/dev/scini"
 	mockGUID    = "9E56672F-2F4B-4A42-BFF4-88B6846FBFDA"
 	mockSystem  = "14dbbf5617523654"
-	drvCfg      = "/opt/emc/scaleio/sdc/bin/drv_cfg"
+	drvCfg      = "/bin/emc/scaleio/drv_cfg"
 )
 
 var (
@@ -178,7 +178,7 @@ func DrvCfgQuerySystems() (*[]ConfiguredCluster, error) {
 		return &clusters, nil
 	}
 
-	output, err := executeFunc("chroot", "/noderoot", drvCfg, "--query_mdm")
+	output, err := executeFunc(drvCfg, "--query_mdm")
 	if err != nil {
 		return nil, fmt.Errorf("failed to query MDM: %v", err)
 	}

--- a/drv_cfg.go
+++ b/drv_cfg.go
@@ -38,7 +38,7 @@ const (
 	IOCTLDevice = "/dev/scini"
 	mockGUID    = "9E56672F-2F4B-4A42-BFF4-88B6846FBFDA"
 	mockSystem  = "14dbbf5617523654"
-	drvCfg      = "/bin/emc/scaleio/drv_cfg"
+	drvCfg      = "/opt/emc/scaleio/sdc/bin/drv_cfg"
 )
 
 var (

--- a/drv_cfg_test.go
+++ b/drv_cfg_test.go
@@ -63,7 +63,9 @@ func TestDrvCfgQuerySystems(t *testing.T) {
 		{
 			name: "passing test",
 			setup: func() {
-				executeFunc = func(_ string, _ ...string) ([]byte, error) {
+				executeFunc = func(cmd string, arg ...string) ([]byte, error) {
+					assert.Equal(t, cmd, "/bin/emc/scaleio/drv_cfg")
+					assert.Equal(t, arg, []string{"--query_mdm"})
 					return []byte("MDM-ID aaaa SDC ID bbbb"), nil
 				}
 			},

--- a/drv_cfg_test.go
+++ b/drv_cfg_test.go
@@ -64,7 +64,7 @@ func TestDrvCfgQuerySystems(t *testing.T) {
 			name: "passing test",
 			setup: func() {
 				executeFunc = func(cmd string, arg ...string) ([]byte, error) {
-					assert.Equal(t, cmd, "/bin/emc/scaleio/drv_cfg")
+					assert.Equal(t, cmd, "/opt/emc/scaleio/sdc/bin/drv_cfg")
 					assert.Equal(t, arg, []string{"--query_mdm"})
 					return []byte("MDM-ID aaaa SDC ID bbbb"), nil
 				}


### PR DESCRIPTION
This change is required to eliminate the unnecessary worker root file system mounting to the driver node container. This broad mount point resulted in duplication of volume mount points (both target paths and private target paths) inside the driver container whenever the driver container restarted. Due to this duplication, stale mount points were left inside the container even after the volumes were removed, one stale mount point per volume.
Also, mounting the entire worker node root file system is unnecessary (we just need /dev and /bin/emc/scaleio/drv_cfg to query MDMs) and highly insecure.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1782 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [] I have commented my code, particularly in hard-to-understand areas
No hard-to-understand areas added.
- [ ] I have made corresponding changes to the documentation
N/A
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?

- [x] goscaleio unit-tests
```

```
