### PR TITLE
Adding the ability to Clone a Template 

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -93,6 +93,12 @@ func NewGateway(host string, username, password string, insecure, useCerts bool)
 		}
 	}
 
+	// For versions greater than 3.5 we need the token in order to get the version.
+	token, err := gc.NewTokenGeneration()
+	if err == nil {
+		gc.token = token
+	}
+
 	version, err := gc.GetVersion()
 	if err != nil {
 		return nil, err

--- a/deploy_test.go
+++ b/deploy_test.go
@@ -74,7 +74,7 @@ func TestNewGateway(t *testing.T) {
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintln(w, `{"access_token":"mock_access_token"}`)
+			fmt.Fprintln(w, `{"access_token":""}`)
 			return
 		}
 		if r.Method == http.MethodGet && r.URL.Path == "/api/version" {
@@ -92,7 +92,7 @@ func TestNewGateway(t *testing.T) {
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintln(w, `{"access_token":"mock_access_token"}`)
+			fmt.Fprintln(w, `{"access_token":""}`)
 			return
 		}
 		if r.Method == http.MethodGet && r.URL.Path == "/api/version" {

--- a/inttests/template_test.go
+++ b/inttests/template_test.go
@@ -45,3 +45,15 @@ func TestGetTemplateByFilters(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Nil(t, templates)
 }
+
+func TestCloneTemplate(t *testing.T) {
+	templates, err := GC.GetTemplateByFilters("category", "Sample Templates")
+	assert.Nil(t, err)
+	assert.NotNil(t, templates)
+
+	system := getSystem()
+	assert.NotNil(t, system)
+
+	errCT := GC.CloneTemplate(system, templates[0].TemplateName+"- Copy", templates[0].OriginalTemplateID)
+	assert.Nil(t, errCT)
+}

--- a/template.go
+++ b/template.go
@@ -159,3 +159,26 @@ func (gc *GatewayClient) GetTemplateByFilters(key string, value string) ([]types
 
 	return templates.TemplateDetails, nil
 }
+
+// CloneTemplate Creates a new Template based on a preexisting Template using the original template id
+func (gc *GatewayClient) CloneTemplate(s *System, originTemplateID string, templateName string) error {
+	defer TimeSpent("CloneTemplate", time.Now())
+	path := `/Api/V1/ServiceTemplate/cloneTemplate`
+
+	template, err := gc.GetTemplateByFilters("originalTemplateId", originTemplateID)
+	if err != nil {
+		return fmt.Errorf("Error While Cloning Template: %s", err.Error())
+	}
+
+	template[0].TemplateLocked = false
+	template[0].Draft = true
+	template[0].TemplateName = templateName
+	template[0].InConfiguration = false
+
+	errCT := s.client.getJSONWithRetry(http.MethodPost, path, template[0], nil)
+	if errCT != nil {
+		return fmt.Errorf("Error While Cloning Template: Template already exists please use a different name")
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description
Added a function that will clone a template based on the user's input of a cloned template name (has to be unique from the template being cloned) and the original template id. Additionally, fixed a bug where tokens weren't being gathered on creation of a Gateway Client affecting terraform providers.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Init Tests
- [x] Unit Tests
  

