### PR TITLE
Updated the GH release action to match the current common GH action functions.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,10 +5,21 @@ on:  # yamllint disable-line rule:truthy
   workflow_call:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to release (major, minor, patch) Ex: 1.0.0'
+      option:
+        description: 'Select version to release'
         required: true
+        type: choice
+        default: 'minor'
+        options:
+          - major
+          - minor
+          - patch
+  repository_dispatch:
+    types: [release-go-libs]
 jobs:
   csm-release:
     uses: dell/common-github-actions/.github/workflows/csm-release-libs.yaml@main
     name: Release Go Client Libraries
+    with:
+      version: "${{ github.event.inputs.option || 'minor' }}"
+    secrets: inherit


### PR DESCRIPTION
# Description
To enable consistent release workflow for the patch release v1.18.1, the GH release action needs to be updated to match the current common GH action functions.



