### PR TITLE
method to get volume metrics for an sdc

### DIFF
--- a/inttests/sdc_test.go
+++ b/inttests/sdc_test.go
@@ -224,3 +224,17 @@ func TestSdcRestrictedMode(t *testing.T) {
 	err = system.SetRestrictedMode("None")
 	assert.Nil(t, err)
 }
+
+// TestGetVolumeMetrics
+func TestGetVolumeMetrics(t *testing.T) {
+	Sdc := getAllSdc(t)
+	assert.NotNil(t, Sdc)
+	if Sdc == nil {
+		return
+	}
+
+	for _, s := range Sdc {
+		_, err := s.GetVolumeMetrics()
+		assert.Nil(t, err)
+	}
+}

--- a/sdc.go
+++ b/sdc.go
@@ -199,8 +199,7 @@ func (sdc *Sdc) GetVolumeMetrics() ([]*types.SdcVolumeMetrics, error) {
 
 	sdcID := sdc.Sdc.ID
 	path := fmt.Sprintf("/api/instances/Sdc::%s/action/queryVolumeSdcBwc", sdcID)
-
-	var body = struct{}{}
+	body := struct{}{}
 	var metrics []*types.SdcVolumeMetrics
 	err := sdc.client.getJSONWithRetry(http.MethodPost, path, body, &metrics)
 	if err != nil {

--- a/sdc.go
+++ b/sdc.go
@@ -201,7 +201,6 @@ func (sdc *Sdc) GetVolumeMetrics() ([]*types.SdcVolumeMetrics, error) {
 	path := fmt.Sprintf("/api/instances/Sdc::%s/action/queryVolumeSdcBwc", sdcID)
 
 	var body = struct{}{}
-
 	var metrics []*types.SdcVolumeMetrics
 	err := sdc.client.getJSONWithRetry(http.MethodPost, path, body, &metrics)
 	if err != nil {

--- a/sdc.go
+++ b/sdc.go
@@ -194,6 +194,23 @@ func (sdc *Sdc) GetVolume() ([]*types.Volume, error) {
 	return vols, nil
 }
 
+func (sdc *Sdc) GetVolumeMetrics() ([]*types.SdcVolumeMetrics, error) {
+	defer TimeSpent("GetVolume", time.Now())
+
+	sdcID := sdc.Sdc.ID
+	path := fmt.Sprintf("/api/instances/Sdc::%s/action/queryVolumeSdcBwc", sdcID)
+
+	var body = struct{}{}
+
+	var metrics []*types.SdcVolumeMetrics
+	err := sdc.client.getJSONWithRetry(http.MethodPost, path, body, &metrics)
+	if err != nil {
+		return nil, err
+	}
+
+	return metrics, nil
+}
+
 // FindVolumes returns volumes
 func (sdc *Sdc) FindVolumes() ([]*Volume, error) {
 	defer TimeSpent("FindVolumes", time.Now())

--- a/sdc_test.go
+++ b/sdc_test.go
@@ -1303,16 +1303,15 @@ func TestGetVolumeMetrics(t *testing.T) {
 			t.Errorf("expected 1 volume info, got %d", len(metrics))
 		}
 
-		if metrics[0].VolumeId != "9d12552300000039" {
-			t.Errorf("expected volume ID 9d12552300000039, got %s", metrics[0].VolumeId)
+		if metrics[0].VolumeID != "9d12552300000039" {
+			t.Errorf("expected volume ID 9d12552300000039, got %s", metrics[0].VolumeID)
 		}
-
 	})
 
 	// Test case 2: Error during retrieval of volume metrics
 	t.Run("error during retrieval", func(t *testing.T) {
 		// Create a test server with an error response
-		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 			w.Write([]byte(`{"error": "mock error"}`))
 		}))
@@ -1341,7 +1340,7 @@ func TestGetVolumeMetrics(t *testing.T) {
 	// Test case 3: Invalid JSON response
 	t.Run("invalid JSON response", func(t *testing.T) {
 		// Create a test server with an invalid JSON response
-		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`invalid JSON`))
 		}))

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -2386,6 +2386,6 @@ type SdcVolumeMetrics struct {
 	TrimLatencyBwc  BWC    `json:"trimLatencyBwc"`
 	WriteBwc        BWC    `json:"writeBwc"`
 	WriteLatencyBwc BWC    `json:"writeLatencyBwc"`
-	VolumeId        string `json:"volumeId"`
-	SdcId           string `json:"sdcId"`
+	VolumeID        string `json:"volumeId"`
+	SdcID           string `json:"sdcId"`
 }

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -2377,3 +2377,15 @@ type OSUserCredential struct {
 	// Required if Private Key is set
 	KeyPairName string `xml:"keyPairName,omitempty"`
 }
+
+// SdcVolumeMetrics represents metrics for a single volume on a single SDC
+type SdcVolumeMetrics struct {
+	ReadLatencyBwc  BWC    `json:"readLatencyBwc"`
+	ReadBwc         BWC    `json:"readBwc"`
+	TrimBwc         BWC    `json:"trimBwc"`
+	TrimLatencyBwc  BWC    `json:"trimLatencyBwc"`
+	WriteBwc        BWC    `json:"writeBwc"`
+	WriteLatencyBwc BWC    `json:"writeLatencyBwc"`
+	VolumeId        string `json:"volumeId"`
+	SdcId           string `json:"sdcId"`
+}


### PR DESCRIPTION
# Description
Added an sdc method to get the volume metrics for an sdc. This will be used by clients like karavi-metrics-powerFlex to query the metrics of multiple volumes for an SDC through a single API call, thereby improving performance.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|  https://github.com/dell/csm/issues/1954|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Added new unit tests and run them successfully
- Added new integration test for the newly added volume metrics method. Result:
```
 -> go test -v -run TestGetVolumeMetrics .
=== RUN   TestGetVolumeMetrics
--- PASS: TestGetVolumeMetrics (0.33s)
PASS
ok      github.com/dell/goscaleio/inttests      0.559s

```
- Created a few volumes/pods on a multi cluster K8s setup with multi array deployment, and able to query metrics using the new method against all the SDC ids through which volumes are attached to the nodes. Below is a sample API response:
```
goscaleio.SdcVolumeMetrics{ReadLatencyBwc:goscaleio.BWC{TotalWeightInKb:0, NumOccured:0, NumSeconds:0}, ReadBwc:goscaleio.BWC{TotalWeightInKb:0, NumOccured:0, NumSeconds:0}, TrimBwc:goscaleio.BWC{TotalWeightInKb:0, NumOccured:0, NumSeconds:0}, TrimLatencyBwc:goscaleio.BWC{TotalWeightInKb:0, NumOccured:0, NumSeconds:0}, WriteBwc:goscaleio.BWC{TotalWeightInKb:0, NumOccured:0, NumSeconds:0}, WriteLatencyBwc:goscaleio.BWC{TotalWeightInKb:0, NumOccured:0, NumSeconds:0}, VolumeID:"9d127e3a0000003b", SdcID:"ed10ad4400000032"}
```

