### PR TITLE
Refactor Approve SDC related methods

### DIFF
--- a/sdc.go
+++ b/sdc.go
@@ -136,26 +136,6 @@ func (s *System) FindSdc(field, value string) (*Sdc, error) {
 	return nil, errors.New("Couldn't find SDC")
 }
 
-// ApproveSdcByGUID approves the Sdc When the Powerflex Array is operating in Guid RestrictedSdcMode.
-func (s *System) ApproveSdcByGUID(sdcGUID string) (*types.ApproveSdcByGUIDResponse, error) {
-	defer TimeSpent("ApproveSdcByGUID", time.Now())
-
-	var resp types.ApproveSdcByGUIDResponse
-
-	path := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", s.System.ID)
-
-	var body types.ApproveSdcParam = types.ApproveSdcParam{
-		SdcGUID: sdcGUID,
-	}
-
-	err := s.client.getJSONWithRetry(http.MethodPost, path, body, &resp)
-	if err != nil {
-		return nil, err
-	}
-
-	return &resp, nil
-}
-
 // GetStatistics returns a Sdc statistcs
 func (sdc *Sdc) GetStatistics() (*types.SdcStatistics, error) {
 	defer TimeSpent("GetStatistics", time.Now())
@@ -384,9 +364,9 @@ func (s *System) SetApprovedIps(sdcID string, sdcApprovedIps []string) error {
 }
 
 // ApproveSdc approves an SDC
-func (s *System) ApproveSdc(approveSdcParam *types.ApproveSdcParam) (*types.ApproveSdcByGUIDResponse, error) {
+func (s *System) ApproveSdc(approveSdcParam *types.ApproveSdcParam) (*types.ApproveSdcResponse, error) {
 	defer TimeSpent("ApproveSdc", time.Now())
-	var resp types.ApproveSdcByGUIDResponse
+	var resp types.ApproveSdcResponse
 
 	path := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", s.System.ID)
 	sdcParam := &types.ApproveSdcParam{

--- a/sdc_test.go
+++ b/sdc_test.go
@@ -178,135 +178,7 @@ func TestRenameSdc(t *testing.T) {
 	}
 }
 
-func TestApproveSdc(t *testing.T) {
-	type checkFn func(*testing.T, *types.ApproveSdcByGUIDResponse, error)
-	check := func(fns ...checkFn) []checkFn { return fns }
-
-	hasNoError := func(t *testing.T, _ *types.ApproveSdcByGUIDResponse, err error) {
-		if err != nil {
-			t.Fatalf("expected no error")
-		}
-	}
-
-	hasError := func(t *testing.T, _ *types.ApproveSdcByGUIDResponse, err error) {
-		if err == nil {
-			t.Fatalf("expected error")
-		}
-	}
-
-	checkResp := func(sdcId string) func(t *testing.T, resp *types.ApproveSdcByGUIDResponse, err error) {
-		return func(t *testing.T, resp *types.ApproveSdcByGUIDResponse, _ error) {
-			assert.Equal(t, sdcId, resp.SdcID)
-		}
-	}
-
-	tests := map[string]func(t *testing.T) (*httptest.Server, *types.System, []checkFn){
-		"success": func(t *testing.T) (*httptest.Server, *types.System, []checkFn) {
-			systemID := "0000aaabbbccc1111"
-			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemID)
-			system := types.System{
-				ID:                       systemID,
-				RestrictedSdcModeEnabled: true,
-				RestrictedSdcMode:        "Guid",
-			}
-
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != http.MethodPost {
-					t.Fatal(fmt.Errorf("wrong method. Expected %s; but got %s", http.MethodPost, r.Method))
-				}
-
-				if r.URL.Path != href {
-					t.Fatal(fmt.Errorf("wrong path. Expected %s; but got %s", href, r.URL.Path))
-				}
-
-				resp := types.ApproveSdcByGUIDResponse{
-					SdcID: "aab12340000000x",
-				}
-
-				respData, err := json.Marshal(resp)
-				if err != nil {
-					t.Fatal(err)
-				}
-				fmt.Fprintln(w, string(respData))
-			}))
-			return ts, &system, check(hasNoError, checkResp("aab12340000000x"))
-		},
-		"Already Approved err": func(t *testing.T) (*httptest.Server, *types.System, []checkFn) {
-			systemID := "0000aaabbbccc1111"
-			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemID)
-			system := types.System{
-				ID:                       systemID,
-				RestrictedSdcModeEnabled: true,
-				RestrictedSdcMode:        "Guid",
-			}
-
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != http.MethodPost {
-					t.Fatal(fmt.Errorf("wrong method. Expected %s; but got %s", http.MethodPost, r.Method))
-				}
-
-				if r.URL.Path != href {
-					t.Fatal(fmt.Errorf("wrong path. Expected %s; but got %s", href, r.URL.Path))
-				}
-
-				http.Error(w, "The SDC is already approved.", http.StatusInternalServerError)
-			}))
-			return ts, &system, check(hasError)
-		},
-		"Invalid guid err": func(t *testing.T) (*httptest.Server, *types.System, []checkFn) {
-			systemID := "0000aaabbbccc1111"
-			href := fmt.Sprintf("/api/instances/System::%v/action/approveSdc", systemID)
-			system := types.System{
-				ID:                       systemID,
-				RestrictedSdcModeEnabled: true,
-				RestrictedSdcMode:        "Guid",
-			}
-
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != http.MethodPost {
-					t.Fatal(fmt.Errorf("wrong method. Expected %s; but got %s", http.MethodPost, r.Method))
-				}
-
-				if r.URL.Path != href {
-					t.Fatal(fmt.Errorf("wrong path. Expected %s; but got %s", href, r.URL.Path))
-				}
-
-				http.Error(w, "The given GUID is invalid. Please specify GUID in the following format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", http.StatusInternalServerError)
-			}))
-			return ts, &system, check(hasError)
-		},
-	}
-
-	testCaseGuids := map[string]string{
-		"success":              "1aaabd94-9acd-11ed-a8fc-0242ac120002",
-		"Already Approved err": "1aaabd94-9acd-11ed-a8fc-0242ac120002",
-		"Invalid guid err":     "invald_guid",
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			ts, system, checkFns := tc(t)
-			defer ts.Close()
-
-			client, err := NewClientWithArgs(ts.URL, "", math.MaxInt64, true, false)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			s := System{
-				client: client,
-				System: system,
-			}
-
-			resp, err := s.ApproveSdcByGUID(testCaseGuids[name])
-			for _, checkFn := range checkFns {
-				checkFn(t, resp, err)
-			}
-		})
-	}
-}
-
-func TestApproveSdcbyIP(t *testing.T) {
+func TestApproveSDC(t *testing.T) {
 	type testCase struct {
 		param    types.ApproveSdcParam
 		expected error
@@ -321,7 +193,9 @@ func TestApproveSdcbyIP(t *testing.T) {
 	cases := []testCase{
 		{
 			param: types.ApproveSdcParam{
-				SdcIP: "10.10.10.10",
+				SdcGUID: "UT3A9C7B2E-7F2D-4A1B-9C3E-8A1FDE9B1234",
+				SdcIP:   "10.10.10.10",
+				SdcIps:  []string{"10.10.10.10"},
 			},
 			expected: nil,
 		},

--- a/sdc_test.go
+++ b/sdc_test.go
@@ -197,7 +197,7 @@ func TestApproveSDC(t *testing.T) {
 				SdcIP:   "10.10.10.10",
 				SdcIps:  []string{"10.10.10.10"},
 			},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte(`{"id": "approved-sdc-id"}`))
 			})),

--- a/sdc_test.go
+++ b/sdc_test.go
@@ -209,7 +209,7 @@ func TestApproveSDC(t *testing.T) {
 			param: types.ApproveSdcParam{
 				Name: "sdc_test",
 			},
-			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
 				w.Write([]byte(`{"message":"Request message is not valid: One of the parameter(s) must be part of the request body: sdcIp, sdcIps, sdcGuid"}`))
 			})),

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -512,8 +512,8 @@ type ApproveSdcParam struct {
 	Name    string   `json:"name,omitempty"`
 }
 
-// ApproveSdcByGUIDResponse defines struct for ApproveSdcByGUIDResponse
-type ApproveSdcByGUIDResponse struct {
+// ApproveSdcResponse defines struct for ApproveSdcResponse
+type ApproveSdcResponse struct {
 	SdcID string `json:"id"`
 }
 


### PR DESCRIPTION
# Description
This PR removes `ApproveSdcByGUID` as both the SDC approval modes (by GUID and by SDC Ip/Ips) will be served by the common method `ApproveSdc`

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1962 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Verified `ApproveSDC` method is being called from the driver when the parameter was enabled.
<img width="1730" height="192" alt="image" src="https://github.com/user-attachments/assets/3b7d9e55-ab63-4082-be33-2726a21f50c9" />

